### PR TITLE
fix(ci): the clippy ratchet passed on a ceiling it could not read

### DIFF
--- a/.github/workflows/clippy-ratchet.yml
+++ b/.github/workflows/clippy-ratchet.yml
@@ -101,6 +101,24 @@ jobs:
           STEP=$(grep '^step' "$RATCHET_FILE" | head -1 | sed 's/.*= *//')
           ACTUAL=$(scripts/check-clippy-ratchet.sh --count)
 
+          # Establish all four operands before doing arithmetic on them. `$(( ))` is the
+          # dangerous half: unlike `[ -gt ]`, which at least ERRORS on a non-integer, it
+          # treats an empty value as 0 SILENTLY -- `CEILING="" STEP=""` gives `NEW=0`. The
+          # clamps below then snap NEW to ACTUAL and this job opens a PR rewriting the
+          # ceiling to whatever the tree currently measures, which does not fail the
+          # ratchet, it DELETES it. A half-written or hand-edited .clippy-ratchet.toml is
+          # the likely way in.
+          for v in CEILING TARGET STEP ACTUAL; do
+            case "${!v}" in
+              ''|*[!0-9]*)
+                echo "::error::$v is not a non-negative integer (read: '${!v}'). Refusing \
+                  to compute a new ceiling from it -- bad arithmetic here rewrites \
+                  $RATCHET_FILE and retires the ratchet silently."
+                exit 1
+                ;;
+            esac
+          done
+
           # Step down, snap to actual when the code is already better than the
           # step, NEVER below actual, and never below target.
           #

--- a/scripts/check-clippy-ratchet.sh
+++ b/scripts/check-clippy-ratchet.sh
@@ -165,6 +165,26 @@ treat this as a broken measurement, not a clean tree."
       exit 1
     fi
     CEILING=$(grep '^ceiling' "$RATCHET_FILE" | head -1 | sed 's/.*= *//')
+    # Establish the operand before comparing on it. A `ceiling` line that exists but is
+    # empty or non-numeric leaves CEILING unusable, and `[ "$COUNT" -gt "" ]` does not
+    # evaluate false -- it ERRORS with "integer expression expected", an `if` CONDITION is
+    # exempt from `set -e`, and the ratchet PASSES. Reproduced: with `ceiling = ` and 500
+    # violations the comparison printed `[: : integer expected` and the script exited 0.
+    #
+    # An ABSENT ceiling line is already safe by accident: grep fails, pipefail propagates,
+    # and `set -e` aborts the assignment. That accident does not cover the malformed case,
+    # which is the likelier one -- a hand-edited or half-written ratchet file.
+    #
+    # Same shape and same remedy as $FLOOR_FILE in check-kani-proof-count.sh, which has
+    # validated its operand all along.
+    case "$CEILING" in
+      ''|*[!0-9]*)
+        echo "::error::$RATCHET_FILE has no usable 'ceiling' (read: '$CEILING'). The ratchet \
+compares the violation count against it numerically, and an unusable value makes the \
+comparison error and the gate pass."
+        exit 2
+        ;;
+    esac
     echo "ratcheted clippy violations: $COUNT (ceiling $CEILING)"
     if [ "$COUNT" -gt "$CEILING" ]; then
       echo "::error::clippy ratchet exceeded: $COUNT > $CEILING."


### PR DESCRIPTION
`check-clippy-ratchet.sh` read the ceiling and compared on it without establishing it:

```sh
CEILING=$(grep '^ceiling' "$RATCHET_FILE" | head -1 | sed 's/.*= *//')
if [ "$COUNT" -gt "$CEILING" ]; then ... exit 1; fi
```

A `ceiling` line that **exists but is empty or non-numeric** leaves `CEILING` unusable, and `[ 500 -gt "" ]` does not evaluate false — it **errors**, an `if` condition is exempt from `set -e`, and the ratchet **passes**.

Reproduced both ways against the real script:

| ratchet file | result |
|---|---|
| `ceiling = ` | `[: : integer expected` → **exit 0** with 500 violations |
| `ceiling = abc` | `[: abc: integer expected` → **exit 0** with 500 violations |

An **absent** ceiling line was already safe, by accident: grep fails, pipefail propagates, `set -e` aborts. That accident does not cover the malformed case, which is the likelier one — a hand-edited or half-written ratchet file.

## The ratchet-down job is worse

`clippy-ratchet.yml` reads the same operands and does **arithmetic** on them. `$(( ))` does not error on a non-integer the way `[ -gt ]` does; it treats an empty value as `0` **silently**:

```
CEILING="" STEP=""  →  NEW=$((CEILING - STEP))  →  NEW=0
```

The clamps then snap `NEW` to `ACTUAL`, and the job opens a PR rewriting the ceiling to whatever the tree currently measures. **That does not fail the ratchet, it deletes it.** All four operands are now checked before the arithmetic.

## Why I own this one

This is #2841's defect in the script **#2832 already edited**. There I validated this file's *other* pin (`.clippy-unanalysed.txt`'s `PINNED`) and left the ceiling beside it unvalidated — exactly the lever-substitution failure recorded as gatehouse **F-84**: pinning the obvious parameter and not enumerating the others that decide the same verdict.

`check-kani-proof-count.sh` has validated its floor all along, so the house style was already in the tree; this adopts it.

## Verification

- Both malformed forms now **exit 2** naming the unusable value; `.clippy-ratchet.toml` restores **byte-exact** at `ceiling = 345`.
- The guard sits where the operand is used rather than at the top of the script: `--count` mode does not read the ceiling, and failing it there would break the ratchet-down job in a new way. So this is not fail-fast, and that is a deliberate trade rather than an oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)