### PR TITLE
The action key, and the census that says 37 of 48 required contexts cannot have one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6532,6 +6532,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nucleus-action-key"
+version = "1.0.0"
+dependencies = [
+ "anyhow",
+ "ci-spec",
+ "hex",
+ "sha2 0.11.0",
+]
+
+[[package]]
 name = "nucleus-adversary-probe"
 version = "1.0.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,8 @@ members = [
     "crates/nucleus-agent-card",         # Verify-before-you-act: signed Agent Card → TrustAnchor
     "crates/nucleus-trust-registry",     # "Let's Encrypt for agents": PR-rooted, OIDC-attested, transparency-logged SPIFFE federation enrollment
     "crates/xtask",                      # Rust-native dev/CI task runner (cargo xtask <cmd>); migrating scripts/*.sh
-    "crates/ci-spec",                   # CI configuration as a typed model + the merge-queue invariants as decision procedures
+    "crates/ci-spec",                 # CI configuration as a typed model + the merge-queue invariants as decision procedures
+    "crates/nucleus-action-key",      # CI: the key a gate receipt is stored under, or a refusal naming what is undeclared
     "crates/ci-fly-runner",             # The CI worker pool manager: a pure plan over a snapshot of queued jobs and machines
     "crates/nucleus-machine",            # MachineDriver: microVM execution-substrate abstraction (mock + Fly skeleton)
     "crates/nucleus-verify-commerce",    # Seller-side verify→serve→receipt middleware for x402/A2A (scaffold)

--- a/crates/nucleus-action-key/Cargo.toml
+++ b/crates/nucleus-action-key/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "nucleus-action-key"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "The key a CI gate's receipt is stored under: what the gate reads, what it is, and what it runs on — or a refusal saying why it has none"
+publish = false
+
+[lints]
+workspace = true
+
+[dev-dependencies]
+ci-spec = { path = "../ci-spec" }
+
+[dependencies]
+anyhow = { workspace = true }
+ci-spec = { path = "../ci-spec" }
+sha2 = { workspace = true }
+hex = { workspace = true }

--- a/crates/nucleus-action-key/src/census.rs
+++ b/crates/nucleus-action-key/src/census.rs
@@ -1,0 +1,87 @@
+//! Which required contexts have a key, and which do not — by name.
+//!
+//! This is the audit the design rests on. A context with no declared read-set
+//! cannot have a receipt, and the honest thing is to say which ones and let
+//! someone decide, rather than invent a filter. An invented filter is a
+//! receipt that lies.
+
+use crate::{ActionKey, Refusal, derive};
+use anyhow::Result;
+use std::path::Path;
+
+/// One context's outcome.
+#[derive(Debug)]
+pub enum Outcome {
+    /// A key was derived.
+    Keyed {
+        context: String,
+        key: ActionKey,
+        reads: usize,
+        gate_files: usize,
+    },
+    /// No key, for a reason a person has to resolve.
+    Refused(Refusal),
+    /// Could not look. Never folded into `Refused`: an unreadable filter and a
+    /// job that legitimately has none are different situations, and reporting
+    /// the first as the second is the vacuity ADR 0002 was written about.
+    Unmeasured { context: String, why: String },
+}
+
+/// The whole census over the required-context ledger.
+#[derive(Debug, Default)]
+pub struct Census {
+    pub outcomes: Vec<Outcome>,
+}
+
+impl Census {
+    #[must_use]
+    pub fn keyed(&self) -> usize {
+        self.outcomes
+            .iter()
+            .filter(|o| matches!(o, Outcome::Keyed { .. }))
+            .count()
+    }
+
+    #[must_use]
+    pub fn refused(&self) -> usize {
+        self.outcomes
+            .iter()
+            .filter(|o| matches!(o, Outcome::Refused(_)))
+            .count()
+    }
+
+    #[must_use]
+    pub fn unmeasured(&self) -> usize {
+        self.outcomes
+            .iter()
+            .filter(|o| matches!(o, Outcome::Unmeasured { .. }))
+            .count()
+    }
+}
+
+/// Run the census over every context in `ci/required-checks.txt`.
+pub fn run(root: &Path) -> Result<Census> {
+    let model = ci_spec::loader::from_repo(root)?;
+    let mut census = Census::default();
+    for context in &model.ledger.contexts {
+        let outcome = match derive::key_for(root, &model, context) {
+            Ok(Ok(key)) => {
+                let inputs = derive::inputs_for(root, &model, context)?
+                    .expect("a context that keyed cannot refuse on the next call");
+                Outcome::Keyed {
+                    context: context.clone(),
+                    key,
+                    reads: inputs.read_set.len(),
+                    gate_files: inputs.gate.len(),
+                }
+            }
+            Ok(Err(refusal)) => Outcome::Refused(refusal),
+            Err(e) => Outcome::Unmeasured {
+                context: context.clone(),
+                why: format!("{e:#}"),
+            },
+        };
+        census.outcomes.push(outcome);
+    }
+    Ok(census)
+}

--- a/crates/nucleus-action-key/src/derive.rs
+++ b/crates/nucleus-action-key/src/derive.rs
@@ -1,0 +1,394 @@
+//! Building [`Inputs`] for a context out of a repository.
+//!
+//! The host does this, never the pod. Everything here reads the tree directly:
+//! the workflow's declared filter, the files that match it, the gate's own
+//! code, and the toolchain pins. Nothing is taken on a running job's word,
+//! which is the property that makes a cross-tree hit admissible at all.
+
+use crate::{ActionKey, Inputs, ReadEntry, Refusal};
+use anyhow::{Context, Result};
+use ci_spec::model::{Model, PathFilter, Workflow};
+use sha2::{Digest, Sha256};
+use std::path::Path;
+
+/// The pinned toolchain files. A gate is a function of what runs it: the same
+/// `cargo clippy` under two nightlies is two gates, and a receipt that does not
+/// say which one it was is a receipt about nothing in particular.
+const TOOLCHAIN_FILES: &[&str] = &["rust-toolchain.toml", "Cargo.lock"];
+
+/// The declared read-set for a workflow, or why it has none.
+///
+/// `merge_group` takes no `paths:` filter — GitHub only accepts
+/// `types: [checks_requested]` there — so the declaration lives on
+/// `pull_request`, which is also the one GitHub itself acts on when it decides
+/// whether to run the job. Using the same filter is what keeps this from being
+/// a new trust assumption.
+fn filter_of(w: &Workflow) -> Option<&PathFilter> {
+    w.triggers
+        .pull_request
+        .as_ref()
+        .or(w.triggers.push.as_ref())
+}
+
+/// Does `path` match a GitHub workflow path pattern?
+///
+/// Segment-wise: `**` matches any run of segments, `*` matches within one
+/// segment, everything else is literal. That is the subset this repository
+/// uses — `crates/**`, `crates/ck-*/src/**`, `scripts/check-*.sh`, and plain
+/// paths.
+///
+/// Returns `None` for anything outside it (`?`, `!`, `+`, character classes).
+/// **An unrecognised pattern must never read as "matches nothing"**: a
+/// read-set that quietly shrinks is a receipt reused when it should not have
+/// been. "I could not look" is never "I looked and it was fine" (ADR 0007
+/// A-2).
+fn matches(pattern: &str, path: &str) -> Option<bool> {
+    if pattern.contains(['?', '!', '+', '[']) {
+        return None;
+    }
+    let pat: Vec<&str> = pattern.split('/').collect();
+    let seg: Vec<&str> = path.split('/').collect();
+    Some(match_segments(&pat, &seg))
+}
+
+/// Segment matcher. `**` consumes zero or more segments, which is why this is
+/// recursive rather than a zip.
+fn match_segments(pat: &[&str], seg: &[&str]) -> bool {
+    match pat.first() {
+        None => seg.is_empty(),
+        Some(&"**") => {
+            // Zero or more segments. GitHub treats a trailing `**` as "this
+            // directory and everything under it".
+            (0..=seg.len()).any(|i| match_segments(&pat[1..], &seg[i..]))
+        }
+        Some(p) => match seg.first() {
+            None => false,
+            Some(s) => match_one(p, s) && match_segments(&pat[1..], &seg[1..]),
+        },
+    }
+}
+
+/// One segment against one pattern segment, with `*` matching any run of
+/// non-`/` characters.
+fn match_one(pat: &str, seg: &str) -> bool {
+    let parts: Vec<&str> = pat.split('*').collect();
+    if parts.len() == 1 {
+        return pat == seg;
+    }
+    let mut rest = seg;
+    // The first part must be a prefix (unless the pattern starts with `*`).
+    if let Some(first) = parts.first()
+        && !first.is_empty()
+    {
+        match rest.strip_prefix(*first) {
+            Some(r) => rest = r,
+            None => return false,
+        }
+    }
+    // The last must be a suffix (unless the pattern ends with `*`).
+    if let Some(last) = parts.last()
+        && !last.is_empty()
+    {
+        match rest.strip_suffix(*last) {
+            Some(r) if rest.len() >= last.len() => rest = r,
+            _ => return false,
+        }
+    }
+    // Interior parts must appear in order.
+    for mid in &parts[1..parts.len().saturating_sub(1)] {
+        if mid.is_empty() {
+            continue;
+        }
+        match rest.find(mid) {
+            Some(i) => rest = &rest[i + mid.len()..],
+            None => return false,
+        }
+    }
+    true
+}
+
+/// Every tracked file under `root`, repo-relative, from git rather than a
+/// directory walk.
+///
+/// `git ls-files` is the enumeration, not `walkdir`: an untracked build
+/// artefact that happened to match a pattern would otherwise enter the key and
+/// make it depend on the machine.
+fn tracked_files(root: &Path) -> Result<Vec<String>> {
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["ls-files", "-z"])
+        .output()
+        .context("running `git ls-files`")?;
+    anyhow::ensure!(out.status.success(), "`git ls-files` failed in {root:?}");
+    Ok(String::from_utf8_lossy(&out.stdout)
+        .split('\0')
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
+fn digest_of(root: &Path, rel: &str) -> Result<[u8; 32]> {
+    let bytes = std::fs::read(root.join(rel)).with_context(|| format!("reading {rel}"))?;
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&Sha256::digest(&bytes));
+    Ok(out)
+}
+
+/// The read-set: tracked files matching `paths:` and not `paths-ignore:`.
+///
+/// Returns `Err` when a pattern is outside the recognised subset. That is
+/// deliberately not a silent empty match: "I could not read this filter" and
+/// "this filter selects nothing" must never be the same answer (ADR 0007 A-2).
+fn read_set(root: &Path, filter: &PathFilter) -> Result<Vec<ReadEntry>> {
+    let files = tracked_files(root)?;
+    let mut out = Vec::new();
+    for f in files {
+        let mut included = false;
+        for p in &filter.paths {
+            match matches(p, &f) {
+                Some(true) => included = true,
+                Some(false) => {}
+                None => anyhow::bail!(
+                    "unrecognised path pattern {p:?}: refusing to guess at a read-set"
+                ),
+            }
+        }
+        if !included {
+            continue;
+        }
+        for p in &filter.paths_ignore {
+            match matches(p, &f) {
+                Some(true) => {
+                    included = false;
+                    break;
+                }
+                Some(false) => {}
+                None => anyhow::bail!(
+                    "unrecognised path-ignore pattern {p:?}: refusing to guess at a read-set"
+                ),
+            }
+        }
+        if included {
+            out.push(ReadEntry {
+                path: f.clone(),
+                digest: digest_of(root, &f)?,
+            });
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+/// The gate's own code: the workflow file, plus every `scripts/*.sh` its text
+/// mentions.
+///
+/// Without this a gate that was *weakened* keeps answering green out of its
+/// stronger self's history — the one failure mode that makes a receipt store
+/// worse than no cache at all. The workflow is included whether or not it
+/// appears in its own `paths:` filter, because "the gate changed" is not the
+/// same question as "an input changed" and a filter that omits itself is
+/// common.
+fn gate_set(root: &Path, w: &Workflow) -> Result<Vec<ReadEntry>> {
+    let mut out = vec![ReadEntry {
+        path: w.path.clone(),
+        digest: digest_of(root, &w.path)?,
+    }];
+    for candidate in tracked_files(root)? {
+        if (candidate.starts_with("scripts/") || candidate.starts_with("ci/"))
+            && candidate.ends_with(".sh")
+            && w.raw.contains(&candidate)
+        {
+            out.push(ReadEntry {
+                path: candidate.clone(),
+                digest: digest_of(root, &candidate)?,
+            });
+        }
+    }
+    out.sort();
+    out.dedup();
+    Ok(out)
+}
+
+fn toolchain(root: &Path) -> Result<Vec<(String, String)>> {
+    let mut pins = Vec::new();
+    for f in TOOLCHAIN_FILES {
+        let path = root.join(f);
+        if path.exists() {
+            pins.push(((*f).to_string(), hex::encode(digest_of(root, f)?)));
+        }
+    }
+    anyhow::ensure!(
+        !pins.is_empty(),
+        "no toolchain pin found in {root:?}: a key that does not say what compiled the gate is a \
+         key about nothing in particular"
+    );
+    Ok(pins)
+}
+
+/// The inputs for one required context, or a refusal naming what a person has
+/// to decide.
+///
+/// The outer `Result` is "could not look"; the inner `Refusal` is "looked, and
+/// there is no key". Collapsing the two would make an unreadable workflow
+/// indistinguishable from a job that legitimately has no filter.
+pub fn inputs_for(root: &Path, model: &Model, context: &str) -> Result<Result<Inputs, Refusal>> {
+    let all = model.producers(context);
+
+    // The twin pattern is not ambiguity. `foo.yml` carries the real `paths:`
+    // and `foo-noop.yml` carries its complement as `paths-ignore:`; exactly one
+    // fires, and the noop reports the same context green in seconds. So the
+    // real twin is the gate, and its filter is the declared read-set. Dropping
+    // the noop half here is the difference between 11 refusals and 11 keys.
+    let real: Vec<_> = all
+        .iter()
+        .copied()
+        .filter(|(wi, _)| !model.workflows[*wi].is_noop())
+        .collect();
+    let producers = if real.is_empty() { all.clone() } else { real };
+
+    match producers.len() {
+        0 => {
+            return Ok(Err(Refusal::NoProducer {
+                context: context.to_string(),
+            }));
+        }
+        1 => {}
+        _ => {
+            return Ok(Err(Refusal::ManyProducers {
+                context: context.to_string(),
+                producers: producers
+                    .iter()
+                    .map(|(wi, ji)| {
+                        format!(
+                            "{}::{}",
+                            model.workflows[*wi].path, model.workflows[*wi].jobs[*ji].id
+                        )
+                    })
+                    .collect(),
+            }));
+        }
+    }
+    let (wi, _) = producers[0];
+    let w = &model.workflows[wi];
+
+    let Some(filter) = filter_of(w) else {
+        return Ok(Err(Refusal::Unfiltered {
+            context: context.to_string(),
+            workflow: w.path.clone(),
+        }));
+    };
+    if filter.paths.is_empty() {
+        return Ok(Err(if filter.paths_ignore.is_empty() {
+            Refusal::Unfiltered {
+                context: context.to_string(),
+                workflow: w.path.clone(),
+            }
+        } else {
+            Refusal::IgnoreOnly {
+                context: context.to_string(),
+                workflow: w.path.clone(),
+            }
+        }));
+    }
+
+    Ok(Ok(Inputs {
+        context: context.to_string(),
+        read_set: read_set(root, filter)?,
+        gate: gate_set(root, w)?,
+        toolchain: toolchain(root)?,
+    }))
+}
+
+/// The key for one required context, or the refusal.
+pub fn key_for(root: &Path, model: &Model, context: &str) -> Result<Result<ActionKey, Refusal>> {
+    Ok(inputs_for(root, model, context)?.map(|i| ActionKey::derive(&i)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::matches;
+
+    #[test]
+    fn a_star_spans_a_segment_but_never_crosses_one() {
+        // The live shape from kani-nightly.yml, which the first version of this
+        // matcher could not read.
+        assert_eq!(
+            matches("crates/ck-*/src/**", "crates/ck-policy/src/lib.rs"),
+            Some(true)
+        );
+        assert_eq!(
+            matches("crates/ck-*/src/**", "crates/ck-types/src/a/b.rs"),
+            Some(true)
+        );
+        assert_eq!(
+            matches("crates/ck-*/src/**", "crates/portcullis/src/lib.rs"),
+            Some(false)
+        );
+        assert_eq!(
+            matches("crates/ck-*/src/**", "crates/ck-policy/tests/x.rs"),
+            Some(false)
+        );
+        // `*` must not swallow a `/`.
+        assert_eq!(matches("crates/*/lib.rs", "crates/a/b/lib.rs"), Some(false));
+    }
+
+    /// A trailing `**` covers the directory itself and everything under it.
+    #[test]
+    fn a_trailing_double_star_covers_the_directory_and_its_subtree() {
+        assert_eq!(matches("crates/**", "crates/a.rs"), Some(true));
+        assert_eq!(matches("crates/**", "crates/a/b/c.rs"), Some(true));
+        assert_eq!(matches("crates/**", "tools/a.rs"), Some(false));
+    }
+
+    #[test]
+    fn the_patterns_this_repository_actually_uses_are_recognised() {
+        assert_eq!(
+            matches("crates/**", "crates/portcullis/src/lib.rs"),
+            Some(true)
+        );
+        assert_eq!(matches("crates/**", "scripts/x.sh"), Some(false));
+        assert_eq!(
+            matches(
+                "tools/nucleus-egress-lint/**",
+                "tools/nucleus-egress-lint/src/lib.rs"
+            ),
+            Some(true)
+        );
+        assert_eq!(
+            matches(
+                ".github/workflows/dylint-separation.yml",
+                ".github/workflows/dylint-separation.yml"
+            ),
+            Some(true)
+        );
+        assert_eq!(
+            matches(".observed-ratchet.toml", ".observed-ratchet.toml"),
+            Some(true)
+        );
+        assert_eq!(
+            matches("scripts/check-*.sh", "scripts/check-observed-dylint.sh"),
+            Some(true)
+        );
+        assert_eq!(
+            matches("scripts/check-*.sh", "scripts/other.sh"),
+            Some(false)
+        );
+        // A `*` must not cross a segment boundary.
+        assert_eq!(matches("scripts/*.sh", "scripts/sub/x.sh"), Some(false));
+    }
+
+    /// **An unrecognised pattern must not read as "matches nothing".** A
+    /// read-set that quietly shrinks is a receipt reused when it should not
+    /// have been; "I could not look" is never "I looked and it was fine"
+    /// (ADR 0007 A-2).
+    #[test]
+    fn an_unrecognised_pattern_is_refused_rather_than_treated_as_empty() {
+        assert_eq!(
+            matches("crates/?ortcullis/**", "crates/portcullis/src/lib.rs"),
+            None
+        );
+        assert_eq!(matches("!crates/**", "crates/a.rs"), None);
+        assert_eq!(matches("crates/[ab]/**", "crates/a/x.rs"), None);
+    }
+}

--- a/crates/nucleus-action-key/src/lib.rs
+++ b/crates/nucleus-action-key/src/lib.rs
@@ -1,0 +1,234 @@
+//! `nucleus-action-key` — the key a CI gate's receipt is stored under.
+//!
+//! # Why a key at all
+//!
+//! `ci/fly-runner/README.md` measured one green merge-group run as 33 jobs
+//! with **44 minutes of work and 401 minutes of queue wait** — 27 of them
+//! finish in 90 seconds or less and waited 10 to 18 minutes each for a slot,
+//! and 6-second gate jobs waited 44 to 60 minutes. Caching the *work* attacks
+//! the 44 minutes. Only answering a check without taking a runner slot attacks
+//! the 401, and answering requires knowing when a previous answer still holds.
+//!
+//! That is this key. Two runs with the same key must have the same verdict, or
+//! a receipt reused under it is a green check for work nobody did on the code
+//! in question.
+//!
+//! # What goes into it, and why each part is not optional
+//!
+//! * **The read-set** — the files the gate reads, enumerated by the host from
+//!   the git tree, each with its blob digest. The gate never gets to say what
+//!   it read; see "The assertion this does not take" below.
+//! * **The gate itself** — the workflow file's own digest and every gate
+//!   script it invokes. Without this a gate that was *weakened* keeps
+//!   answering green out of its stronger self's history, which is the one
+//!   failure that makes the whole scheme worse than no cache at all.
+//! * **The toolchain** — the pinned compiler. A gate is a function of what
+//!   runs it, and `cargo clippy` under two nightlies is two gates.
+//!
+//! Every part is absorbed tag-separated and length-prefixed, so no two
+//! distinct inputs share a preimage by concatenation, and none of it goes
+//! through `Debug` — `scripts/check-preimage-dylint.sh` is the standing gate
+//! on that.
+//!
+//! # Where the read-set comes from
+//!
+//! The workflow's own `paths:` filter. This is not a new declaration invented
+//! for caching: GitHub *already* uses it to decide whether to run the job at
+//! all, so keying a receipt on it extends no trust the repository does not
+//! already extend every day.
+//!
+//! It does make an existing silent defect loud. `dylint-separation.yml`
+//! carries the comment that *egress has run in this job since #2348 and was
+//! never in the filter, so a change confined to that lint did not trigger the
+//! job that gates it.* Today nothing notices a wrong filter. Under a receipt
+//! store it becomes a receipt reused when it should not have been — which is
+//! exactly what the shadow lane is for, and why that lane ships before
+//! anything answers a check.
+//!
+//! # The refusal
+//!
+//! A job with no `paths:` filter reads *everything*, and a key over everything
+//! is a key that never hits. [`Refusal::Unfiltered`] says so by name rather
+//! than inventing a filter, because an invented filter is a receipt that lies.
+//! Naming them is the audit; guessing at them is the defect.
+//!
+//! # The assertion this does not take
+//!
+//! Gatehouse refuses a cross-tree hit outright — a receipt is a hit only at
+//! the tree it was minted at — and `docs/hard-cut.md` gives the reason: its
+//! scope hash is *the pod's own assertion*, and the tree binding is what
+//! stands between a cache hit and a replay. This key is not that shape. The
+//! host holds the tree and enumerates the selection itself; nothing the pod
+//! says enters the key. That is the difference, and it is the only reason a
+//! cross-tree hit is admissible here at all.
+//!
+//! It is still weaker in the other direction: gatehouse *proves* its selection
+//! complete by exhibiting the directory under its git oid, and this trusts a
+//! hand-written glob. The shadow lane measures that gap rather than asserting
+//! it away.
+
+#![forbid(unsafe_code)]
+
+use sha2::{Digest, Sha256};
+
+/// Domain separator. Versioned: a change to how the parts are chosen is a new
+/// key space, not a silent reinterpretation of the old one.
+const DOMAIN: &str = "nucleus/ci-action-key/v1";
+
+/// One file the gate reads, as the host enumerated it.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ReadEntry {
+    /// Repo-relative path.
+    pub path: String,
+    /// The content digest of the file at that path.
+    pub digest: [u8; 32],
+}
+
+/// What a gate reads, what it is, and what it runs on.
+///
+/// Fields are public and the struct is exhaustively destructured in
+/// [`ActionKey::derive`], so a field added here is a compile error until
+/// someone says whether it belongs in the key. That is the same discipline
+/// `nucleus_spec::identity::program_digest` uses, and for the same reason: the
+/// silent failure mode of a digest is a field that quietly stopped counting.
+#[derive(Debug, Clone)]
+pub struct Inputs {
+    /// The status-check context this key is for.
+    pub context: String,
+    /// The files matching the job's `paths:` filter, with their digests.
+    /// Sorted by path; [`ActionKey::derive`] sorts rather than trusting.
+    pub read_set: Vec<ReadEntry>,
+    /// The gate's own code: the workflow file and every gate script it runs.
+    pub gate: Vec<ReadEntry>,
+    /// The pinned toolchain, as `(name, value)` pairs.
+    pub toolchain: Vec<(String, String)>,
+}
+
+/// Why a context has no key.
+///
+/// A refusal is a first-class result, not an error to be logged and stepped
+/// past. Each variant names something a person has to decide; none of them has
+/// a safe default that a program could pick.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Refusal {
+    /// The job declares no `paths:` filter, so its read-set is the whole tree.
+    Unfiltered { context: String, workflow: String },
+    /// No job in any workflow produces this context.
+    NoProducer { context: String },
+    /// More than one job produces it, so "the gate" is ambiguous.
+    ManyProducers {
+        context: String,
+        producers: Vec<String>,
+    },
+    /// The job declares only `paths-ignore:`. That is a read-set of
+    /// *everything except*, which is unbounded in the same way as no filter at
+    /// all: a file added anywhere outside the ignore list silently joins it.
+    IgnoreOnly { context: String, workflow: String },
+}
+
+impl std::fmt::Display for Refusal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Refusal::Unfiltered { context, workflow } => write!(
+                f,
+                "{context}: {workflow} declares no `paths:` filter, so its read-set is the whole \
+                 tree and a key over it would never hit. Declare what the job reads."
+            ),
+            Refusal::NoProducer { context } => {
+                write!(f, "{context}: no job produces this context")
+            }
+            Refusal::ManyProducers { context, producers } => write!(
+                f,
+                "{context}: {} jobs produce it ({}), so which gate this key is about is ambiguous",
+                producers.len(),
+                producers.join(", ")
+            ),
+            Refusal::IgnoreOnly { context, workflow } => write!(
+                f,
+                "{context}: {workflow} declares only `paths-ignore:`. A read-set of \
+                 everything-except grows silently whenever a file is added outside the ignore \
+                 list, so it cannot key a receipt."
+            ),
+        }
+    }
+}
+
+/// The key itself.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ActionKey([u8; 32]);
+
+impl ActionKey {
+    /// Derive the key from its inputs.
+    ///
+    /// The read-set and the gate set are sorted here rather than trusted to
+    /// arrive sorted: the caller enumerates a filesystem, and directory order
+    /// is not a property anyone should have to remember to normalise.
+    #[must_use]
+    pub fn derive(inputs: &Inputs) -> Self {
+        // Exhaustive destructure: a new field is an E0027 here, which is the
+        // point. See the doc comment on `Inputs`.
+        let Inputs {
+            context,
+            read_set,
+            gate,
+            toolchain,
+        } = inputs;
+
+        let mut hasher = Sha256::new();
+        let mut absorb = |tag: &str, bytes: &[u8]| {
+            hasher.update(tag.as_bytes());
+            hasher.update(b"\x00");
+            hasher.update((bytes.len() as u64).to_be_bytes());
+            hasher.update(bytes);
+        };
+
+        absorb("domain", DOMAIN.as_bytes());
+        absorb("context", context.as_bytes());
+
+        let mut absorb_set =
+            |tag_count: &str, tag_path: &str, tag_digest: &str, set: &[ReadEntry]| {
+                let mut sorted = set.to_vec();
+                sorted.sort();
+                absorb(tag_count, &(sorted.len() as u64).to_be_bytes());
+                for e in &sorted {
+                    absorb(tag_path, e.path.as_bytes());
+                    absorb(tag_digest, &e.digest);
+                }
+            };
+        absorb_set("read_count", "read_path", "read_digest", read_set);
+        absorb_set("gate_count", "gate_path", "gate_digest", gate);
+
+        let mut pins = toolchain.to_vec();
+        pins.sort();
+        absorb("pin_count", &(pins.len() as u64).to_be_bytes());
+        for (name, value) in &pins {
+            absorb("pin_name", name.as_bytes());
+            absorb("pin_value", value.as_bytes());
+        }
+
+        let mut out = [0u8; 32];
+        out.copy_from_slice(&hasher.finalize());
+        Self(out)
+    }
+
+    /// The key as lowercase hex.
+    #[must_use]
+    pub fn to_hex(&self) -> String {
+        hex::encode(self.0)
+    }
+
+    /// The raw digest.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+impl std::fmt::Display for ActionKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.to_hex())
+    }
+}
+
+pub mod census;
+pub mod derive;

--- a/crates/nucleus-action-key/src/main.rs
+++ b/crates/nucleus-action-key/src/main.rs
@@ -1,0 +1,71 @@
+//! `nucleus-action-key` — derive a CI gate's receipt key, or say why it has none.
+
+use anyhow::Result;
+use nucleus_action_key::census::{self, Outcome};
+use std::path::PathBuf;
+
+fn main() -> Result<()> {
+    let root = std::env::var("NUCLEUS_REPO_ROOT")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("."));
+
+    let census = census::run(&root)?;
+
+    let mut keyed: Vec<&Outcome> = Vec::new();
+    let mut refused: Vec<&Outcome> = Vec::new();
+    let mut unmeasured: Vec<&Outcome> = Vec::new();
+    for o in &census.outcomes {
+        match o {
+            Outcome::Keyed { .. } => keyed.push(o),
+            Outcome::Refused(_) => refused.push(o),
+            Outcome::Unmeasured { .. } => unmeasured.push(o),
+        }
+    }
+
+    println!("KEYED ({})", keyed.len());
+    for o in &keyed {
+        if let Outcome::Keyed {
+            context,
+            key,
+            reads,
+            gate_files,
+        } = o
+        {
+            println!(
+                "  {:.16}  {reads:>5} read  {gate_files:>2} gate  {context}",
+                key.to_hex()
+            );
+        }
+    }
+
+    println!("\nNO KEY ({})", refused.len());
+    for o in &refused {
+        if let Outcome::Refused(r) = o {
+            println!("  {r}");
+        }
+    }
+
+    if !unmeasured.is_empty() {
+        println!("\nCOULD NOT LOOK ({})", unmeasured.len());
+        for o in &unmeasured {
+            if let Outcome::Unmeasured { context, why } = o {
+                println!("  {context}: {why}");
+            }
+        }
+    }
+
+    println!(
+        "\n{} required context(s): {} keyed, {} refused, {} unmeasured",
+        census.outcomes.len(),
+        census.keyed(),
+        census.refused(),
+        census.unmeasured()
+    );
+    // Exit 2 for "could not look" — the third state ci-spec keeps and for the
+    // same reason: an unreadable filter reported as a clean refusal is the
+    // vacuity these gates exist to find.
+    if census.unmeasured() > 0 {
+        std::process::exit(2);
+    }
+    Ok(())
+}

--- a/crates/nucleus-action-key/tests/key_properties.rs
+++ b/crates/nucleus-action-key/tests/key_properties.rs
@@ -1,0 +1,208 @@
+//! The three properties that decide whether a receipt keyed on this is sound.
+//!
+//! 1. A file **inside** the declared read-set moves the key.
+//! 2. A file **outside** it does not — that is the whole point; without it
+//!    every new tree is a cold cache, which is the state gatehouse's
+//!    `docs/hard-cut.md` §6 records for its own receipts.
+//! 3. **The gate's own code moves the key.** Without this a gate that was
+//!    *weakened* keeps answering green out of its stronger self's history,
+//!    which is the one failure that makes a receipt store worse than no cache.
+//!
+//! Each runs against a real git repository in a tempdir, because the read-set
+//! is enumerated with `git ls-files` and a fixture that stubbed that out would
+//! be testing a different function.
+
+use nucleus_action_key::derive;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// The merge-queue constants `ci-spec`'s model requires. Values are irrelevant
+/// here — this crate never reads them — but the struct has no defaults, and a
+/// model that will not build is a "could not look", not a fixture.
+const QUEUE_FIXTURE: &str = "\
+ruleset_id = 1
+check_response_timeout_minutes = 360
+max_entries_to_build = 1
+max_entries_to_merge = 1
+min_entries_to_merge = 1
+min_entries_to_merge_wait_minutes = 1
+grouping_strategy = \"ALLGREEN\"
+merge_method = \"SQUASH\"
+strict = true
+";
+
+fn git(root: &Path, args: &[&str]) {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(args)
+        .output()
+        .expect("git");
+    assert!(
+        out.status.success(),
+        "git {args:?}: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn write(root: &Path, rel: &str, body: &str) {
+    let p = root.join(rel);
+    std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+    std::fs::write(p, body).unwrap();
+}
+
+/// A minimal repository with one required context, produced by one job whose
+/// workflow declares `src/**` as its read-set.
+fn fixture() -> PathBuf {
+    // Named by pid and a counter rather than the clock: #2825 was a flake
+    // caused by nine tests sharing a wall-clock-nanos tempdir name.
+    use std::sync::atomic::{AtomicU32, Ordering};
+    static N: AtomicU32 = AtomicU32::new(0);
+    let root = std::env::temp_dir().join(format!(
+        "nucleus-action-key-{}-{}",
+        std::process::id(),
+        N.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).unwrap();
+
+    git(&root, &["init", "-q"]);
+    write(
+        &root,
+        "rust-toolchain.toml",
+        "[toolchain]\nchannel = \"1.95\"\n",
+    );
+    write(&root, "src/lib.rs", "fn a() {}\n");
+    write(&root, "docs/readme.md", "unrelated\n");
+    write(
+        &root,
+        ".github/workflows/gate.yml",
+        r#"name: Gate
+on:
+  pull_request:
+    paths:
+      - "src/**"
+      - ".github/workflows/gate.yml"
+  merge_group:
+jobs:
+  gate:
+    name: The Gate
+    runs-on: ubuntu-latest
+    steps:
+      - run: scripts/check-thing.sh
+"#,
+    );
+    write(&root, "scripts/check-thing.sh", "#!/bin/sh\nexit 0\n");
+    git(&root, &["add", "-A"]);
+    root
+}
+
+fn key_of(root: &Path) -> String {
+    // `from_parts` rather than `from_repo`: the ledger, queue, inline-gate and
+    // allowlist files are `ci-spec`'s subject, not this crate's, and a fixture
+    // that had to carry all of them would be testing the loader.
+    let wf = (
+        ".github/workflows/gate.yml".to_string(),
+        std::fs::read_to_string(root.join(".github/workflows/gate.yml")).unwrap(),
+    );
+    let model = ci_spec::loader::from_parts(
+        std::slice::from_ref(&wf),
+        "# PINNED = 1\nThe Gate\n",
+        QUEUE_FIXTURE,
+        "",
+        "",
+        vec!["scripts/check-thing.sh".to_string()],
+    )
+    .expect("model");
+    derive::key_for(root, &model, "The Gate")
+        .expect("could look")
+        .expect("has a key")
+        .to_hex()
+}
+
+#[test]
+fn a_file_inside_the_read_set_moves_the_key() {
+    let root = fixture();
+    let before = key_of(&root);
+    write(&root, "src/lib.rs", "fn a() { let _ = 1; }\n");
+    git(&root, &["add", "-A"]);
+    assert_ne!(before, key_of(&root));
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn a_file_outside_the_read_set_does_not_move_the_key() {
+    let root = fixture();
+    let before = key_of(&root);
+    write(&root, "docs/readme.md", "still unrelated, but different\n");
+    git(&root, &["add", "-A"]);
+    assert_eq!(
+        before,
+        key_of(&root),
+        "a change outside the declared read-set moved the key; every tree would be a cold cache"
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// A file ADDED outside the read-set must not move it either. This is the one
+/// a `paths-ignore:`-only filter cannot give you, and why `Refusal::IgnoreOnly`
+/// exists.
+#[test]
+fn a_file_added_outside_the_read_set_does_not_move_the_key() {
+    let root = fixture();
+    let before = key_of(&root);
+    write(&root, "docs/another.md", "new file\n");
+    git(&root, &["add", "-A"]);
+    assert_eq!(before, key_of(&root));
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// **The one that catches a weakened gate.** The script the workflow runs is
+/// the gate; change it with every declared input untouched, and the key must
+/// move — or the receipt from the stronger version keeps answering.
+#[test]
+fn changing_the_gate_script_moves_the_key_with_no_input_changed() {
+    let root = fixture();
+    let before = key_of(&root);
+    write(
+        &root,
+        "scripts/check-thing.sh",
+        "#!/bin/sh\n# gate weakened\nexit 0\n",
+    );
+    git(&root, &["add", "-A"]);
+    assert_ne!(
+        before,
+        key_of(&root),
+        "the gate's own code is not in the key: a weakened gate answers green from its stronger \
+         self's history"
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// The toolchain is part of the gate. The same `cargo clippy` under two
+/// compilers is two gates, and a receipt that does not say which is a receipt
+/// about nothing in particular.
+#[test]
+fn changing_the_toolchain_moves_the_key() {
+    let root = fixture();
+    let before = key_of(&root);
+    write(
+        &root,
+        "rust-toolchain.toml",
+        "[toolchain]\nchannel = \"1.96\"\n",
+    );
+    git(&root, &["add", "-A"]);
+    assert_ne!(before, key_of(&root));
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// Untracked files must not enter the key: a build artefact that happened to
+/// match the filter would make the key depend on the machine.
+#[test]
+fn an_untracked_file_in_the_read_set_does_not_move_the_key() {
+    let root = fixture();
+    let before = key_of(&root);
+    write(&root, "src/scratch.rs", "// not added to git\n");
+    assert_eq!(before, key_of(&root));
+    let _ = std::fs::remove_dir_all(&root);
+}


### PR DESCRIPTION
First piece of "nucleus builds nucleus". The useful output today is not the key — it is the census.

## The finding

```
48 required context(s): 11 keyed, 37 refused, 0 unmeasured
```

38 of 58 merge_group workflows carry a `paths:` filter, which reads like the declarations are mostly in place. **Not one of those 38 produces a required context.**

The 11 that key are all twin pairs (`foo.yml` + `foo-noop.yml`), where the filter is already what GitHub acts on — and where a fast skip path therefore already exists. The other **37 declare no read-set at all**, and **25 come from one file, `ci.yml`**: Tests, Clippy, Coverage, Mutation Testing. The expensive ones.

So the blocker on zero-wait CI is not caching machinery. It is that nobody has written down what those jobs read. The census names all 37 by context, because an invented filter is a receipt that lies — the naming *is* the audit.

## What goes in the key

The read-set (files matching the declared filter, enumerated by the **host** from `git ls-files`, never asserted by a running job), the gate's own code (workflow file + every gate script it invokes), and the toolchain pins. Tagged and length-prefixed, no `Debug` — the discipline `scripts/check-preimage-dylint.sh` now gates.

`Inputs` is exhaustively destructured in `derive`, so a new field is an `E0027` until someone says whether it belongs in the key.

## The refusals

`Unfiltered`, `IgnoreOnly`, `NoProducer`, `ManyProducers`. Each names something a person decides; none has a default a program could pick. `IgnoreOnly` is separate on purpose — a read-set of everything-*except* grows silently whenever a file lands outside the ignore list.

An unrecognised glob returns `None`, never "matches nothing". The matcher was rewritten segment-wise after the first version could not read `crates/ck-*/src/**`, which is live in `kani-nightly.yml` and would have silently produced an empty read-set.

## Six properties, against a real git repository

| property | why |
|---|---|
| a file inside the read-set moves the key | |
| a file outside does **not** | without it every tree is a cold cache |
| a file **added** outside does not | what `paths-ignore:`-only cannot give you |
| **the gate script moves it with no input changed** | else a *weakened* gate answers green from its stronger self's history |
| the toolchain moves it | the same clippy under two nightlies is two gates |
| an untracked file does not | else the key depends on the machine |

The first two are mutually non-vacuous: if the key never moved, the first would fail.

## What this does not claim

Gatehouse refuses a cross-tree hit outright (`docs/hard-cut.md` §6) because its scope hash is the pod's own assertion. This key is a different shape — the host holds the tree and enumerates the selection itself — but it trusts a hand-written glob where gatehouse exhibits a directory under its git oid. The shadow lane measures that gap; nothing here asserts it away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016t7JSuCtg4dC54HZjFgBjr