### PR TITLE
Eleven grep gates share a pod, and the relays leave the pool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,51 +122,120 @@ jobs:
       - name: cargo fmt
         run: cargo fmt --all -- --check
 
-  verify-strict:
-    name: Ed25519 verify_strict gate (M-3)
+  # ── The grep-only gates, ONCE per pod ─────────────────────────────────────
+  #
+  # Eleven jobs that each took a pod to run ONE `scripts/check-*.sh` over the
+  # checked-out tree. Measured on #2848, across its pull_request and
+  # merge_group runs: 2,297 seconds of slot wait for 178 seconds of work.
+  # Thirteen times more waiting than working, to run eleven greps.
+  #
+  # WHY THE RELAYS RUN ON GITHUB-HOSTED, WHICH IS THE WHOLE TRICK
+  #
+  # There is no build to share here. That makes this different from the
+  # live-path and workspace consolidations, where the saving was one cargo
+  # build instead of three — and it means the relay jobs decide whether this
+  # change is worth anything at all. A relay does nothing but read a step
+  # outcome, but if it asks for `vars.CI_RUNNER` it takes a pool slot exactly
+  # like the job it replaced, and eleven of those give back everything this
+  # job saves. On hosted runners they cost the pool nothing.
+  #
+  # (The four live-path relays below moved for the same reason. They were on
+  # the pool, which is why #2635's consolidation won on build time and lost on
+  # slot acquisitions.)
+  #
+  # WHAT MAY RIDE ALONG
+  #
+  # Read-only text gates only. Every script here was checked: none writes to
+  # the tree. A gate that PERTURBS files cannot share a pod with gates that
+  # read them — that is why `check-gates-can-fail.sh` runs last inside
+  # `live-path-gates` and not here.
+  #
+  # Each step is `continue-on-error`, so the job is green even when a gate
+  # reds; the relays below turn each outcome back into its own required
+  # context. No context name changes, so `ci/required-checks.txt` and branch
+  # protection are untouched.
+  text-gates:
+    name: Text gates (one pod)
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 5
+    timeout-minutes: 15
+    outputs:
+      verify_strict: ${{ steps.verify_strict.outcome }}
+      sandbox_trusted_base: ${{ steps.sandbox_trusted_base.outcome }}
+      failclosed: ${{ steps.failclosed.outcome }}
+      mediation: ${{ steps.mediation.outcome }}
+      north_star: ${{ steps.north_star.outcome }}
+      extracted_callsites: ${{ steps.extracted_callsites.outcome }}
+      task_compiler: ${{ steps.task_compiler.outcome }}
+      ingest_hash: ${{ steps.ingest_hash.outcome }}
+      kani_divergence: ${{ steps.kani_divergence.outcome }}
+      sealed_home: ${{ steps.sealed_home.outcome }}
+      governor_keys: ${{ steps.governor_keys.outcome }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Forbid non-strict dalek .verify(...) on trust paths
+        id: verify_strict
+        continue-on-error: true
         run: scripts/check-verify-strict.sh
-
-  sandbox-trusted-base-gate:
-    name: Sandbox trusted-base gate
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Every pin names a real test; the unpinned set may only shrink
+        id: sandbox_trusted_base
+        continue-on-error: true
         run: scripts/check-sandbox-trusted-base.sh
-
-  failclosed-verifier-gate:
-    name: Fail-closed verifier gate
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Forbid a verifier that reports success where it cannot check
+        id: failclosed
+        continue-on-error: true
         run: scripts/check-failclosed-verifiers.sh
-
-  mediation-gate:
-    name: Mediation backstop gate (North Star)
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Forbid raw agent-path effect primitives outside the discharge-gated API
+        id: mediation
+        continue-on-error: true
         run: scripts/check-mediation.sh
+      - name: Every status row is earned, evidenced, and uncontradicted
+        id: north_star
+        continue-on-error: true
+        run: scripts/check-north-star-ledger.sh
+      - name: Every extracted predicate's enforcement is still wired
+        id: extracted_callsites
+        continue-on-error: true
+        run: scripts/check-extracted-callsites.sh
+      - name: No network crate in its dependency tables, no socket type in its sources
+        id: task_compiler
+        continue-on-error: true
+        run: scripts/check-task-compiler-offline.sh
+      - name: Forbid non-hashing agent-path ingest observes (content-address every input)
+        id: ingest_hash
+        continue-on-error: true
+        run: scripts/check-ingest-hashed.sh
+      - name: Every cfg(kani) site is listed and justified; the total only shrinks
+        id: kani_divergence
+        continue-on-error: true
+        env:
+          # The script fetches this ref itself (checkout is depth 1).
+          KANI_DIVERGENCE_BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || '' }}
+          # Owner override for a deliberate new divergence: the PR label.
+          KANI_DIVERGENCE_ALLOW_GROWTH: ${{ contains(github.event.pull_request.labels.*.name, 'kani-divergence-growth') && '1' || '0' }}
+        run: scripts/check-kani-divergence.sh
+      - name: Forbid raw effect primitives outside the sealed RealEffects home
+        id: sealed_home
+        continue-on-error: true
+        run: scripts/check-sealed-home.sh
+      - name: set_trusted_keys has no caller outside kernel construction
+        id: governor_keys
+        continue-on-error: true
+        run: scripts/check-declassify-governor-keys-sealed.sh
+      - name: Outcomes
+        if: always()
+        run: |
+          echo "- verify_strict: ${{ steps.verify_strict.outcome }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- sandbox_trusted_base: ${{ steps.sandbox_trusted_base.outcome }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- failclosed: ${{ steps.failclosed.outcome }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- mediation: ${{ steps.mediation.outcome }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- north_star: ${{ steps.north_star.outcome }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- extracted_callsites: ${{ steps.extracted_callsites.outcome }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- task_compiler: ${{ steps.task_compiler.outcome }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ingest_hash: ${{ steps.ingest_hash.outcome }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- kani_divergence: ${{ steps.kani_divergence.outcome }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- sealed_home: ${{ steps.sealed_home.outcome }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- governor_keys: ${{ steps.governor_keys.outcome }}" >> "$GITHUB_STEP_SUMMARY"
 
-  # `discharge::test_helpers::bundle_for` mints a DischargedBundle with no
-  # preflight. It is gated behind a `test-helpers` feature that only
-  # [dev-dependencies] enable — and Cargo unifies features per build, so one line
-  # moving to [dependencies] makes the proof mintable from production code with
-  # every test still green, because tests already have the feature on.
-  #
-  # This needs cargo (it reads the resolved no-dev feature graph rather than
-  # grepping manifests, which would miss transitive enabling), so it gets a
-  # toolchain rather than riding along with the grep-only gates above.
   test-helpers-seal:
     name: test-helpers is not reachable from a shipping build
     runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
@@ -210,64 +279,6 @@ jobs:
         shell: bash
         run: scripts/check-declassify-value-bound.sh
 
-  declassify-governor-keys-sealed:
-    name: Governor trusted-key set is not workload-writable
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: set_trusted_keys has no caller outside kernel construction
-        shell: bash
-        run: scripts/check-declassify-governor-keys-sealed.sh
-
-  north-star-ledger:
-    name: The North Star status table cannot outrun its wiring
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Every status row is earned, evidenced, and uncontradicted
-        shell: bash
-        run: scripts/check-north-star-ledger.sh
-
-  # C8 — the Aeneas-extracted predicates carry the flagship theorems; this
-  # asserts each manifest-covered predicate still has a LIVE production call site
-  # (production region, test blocks excluded), so a theorem cannot silently
-  # become a proof about dead code. Runs on every PR (no path filter), so it
-  # covers the live-path crates (nucleus-tool-proxy spawn path, portcullis
-  # kernel) that the scoped Aeneas proof job's trigger does not.
-  extracted-callsites:
-    name: Extracted predicates have live call sites (C8)
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Every extracted predicate's enforcement is still wired
-        shell: bash
-        run: scripts/check-extracted-callsites.sh
-
-  # The delegation compiler (crates/nucleus-task-compiler) turns a goal into
-  # a minimum-authority grant and must never open a socket: an LLM-backed
-  # proposer is a child process outside nucleus, not a dependency of the
-  # compiler. Text-level so the gate-of-gates can probe it without cargo.
-  task-compiler-offline:
-    name: The task compiler is offline by construction
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: No network crate in its dependency tables, no socket type in its sources
-        shell: bash
-        run: scripts/check-task-compiler-offline.sh
-
-  # CI-1: the CI configuration itself is sound. A typed model of every
-  # workflow, the required-check ledger (ci/required-checks.txt) and the
-  # merge-queue pin (ci/merge-queue.toml), and the invariants the queue relies
-  # on decided over it — one producer per required context, twin lists
-  # set-equal, nothing skippable under merge_group, no fail-open gate shape,
-  # timeouts inside the queue budget, every gate wired and inventoried. Each
-  # invariant carries a fixture of the defect it was written for
-  # (crates/ci-spec/tests). Exit 2 ("could not look") is red, never green.
   ci-spec:
     name: CI configuration is sound (CI-1)
     # The GATE pool, not the build pool. This job's verdict is a function of workflow
@@ -319,55 +330,6 @@ jobs:
         shell: bash
         run: cargo run -q -p xtask -- assurance-required
 
-  ingest-hash-gate:
-    name: No-unwitnessed-ingest gate (InputsAuthorized)
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Forbid non-hashing agent-path ingest observes (content-address every input)
-        run: scripts/check-ingest-hashed.sh
-
-  kani-divergence-gate:
-    name: cfg(kani) divergences are inventoried and ratcheted
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Every cfg(kani) site is listed and justified; the total only shrinks
-        env:
-          # The script fetches this ref itself (checkout is depth 1).
-          KANI_DIVERGENCE_BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || '' }}
-          # Owner override for a deliberate new divergence: the PR label.
-          KANI_DIVERGENCE_ALLOW_GROWTH: ${{ contains(github.event.pull_request.labels.*.name, 'kani-divergence-growth') && '1' || '0' }}
-        run: scripts/check-kani-divergence.sh
-
-  sealed-home-gate:
-    name: Sealed-home integrity gate (North Star)
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Forbid raw effect primitives outside the sealed RealEffects home
-        run: scripts/check-sealed-home.sh
-
-  # ── The workspace build, ONCE per pod ─────────────────────────────────────
-  #
-  # Tests, Doctests, the OWASP gauntlet, the K4 parity pin, and the SDK tests
-  # used to be five jobs, each compiling the workspace on its own ephemeral pod.
-  # On four build runners that is the whole PR wall clock: a rebase wave of
-  # eight PRs queued ~80 compile jobs and took an hour. They are now STEPS of
-  # one job on one warm target dir, with the same five status contexts kept as
-  # reporter jobs below (branch protection names them; nothing is dropped).
-  #
-  # On pull_request the run is SCOPED: only the crates the diff touches, closed
-  # under reverse dependencies (scripts/affected-crates.sh — a change to
-  # portcullis-core re-tests nucleus-node). merge_group and push run the whole
-  # workspace, so integration is validated before anything lands; a
-  # workspace-wide change (Cargo.toml/lock, .github/) forces the full run too.
-  #
-  # Drafts are skipped (a stacked child re-runs everything on every base
-  # change); ready_for_review is a trigger above so the run starts on ready.
   workspace-tests:
     name: Workspace build + tests (one pod)
     runs-on: ${{ vars.CI_BUILD_RUNNER || vars.CI_RUNNER || 'ubuntu-latest' }}
@@ -672,7 +634,9 @@ jobs:
 
   declassify-sink-scope-enforced:
     name: Declassify sink scope is enforced
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    # GitHub-hosted: a relay that only reads a step outcome should not hold a
+    # pool slot. See `text-gates`.
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: live-path-gates
     if: always()
@@ -687,7 +651,9 @@ jobs:
 
   cross-pod-lineage:
     name: The node records pod lineage on the live path (C2)
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    # GitHub-hosted: a relay that only reads a step outcome should not hold a
+    # pool slot. See `text-gates`.
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: live-path-gates
     if: always()
@@ -702,7 +668,9 @@ jobs:
 
   c1-inbound-fences-enforced:
     name: C1 inbound fences are enforced
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    # GitHub-hosted: a relay that only reads a step outcome should not hold a
+    # pool slot. See `text-gates`.
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: live-path-gates
     if: always()
@@ -717,7 +685,9 @@ jobs:
 
   gates-can-fail:
     name: Gates must fail on their own subject
-    runs-on: ${{ vars.CI_RUNNER || 'ubuntu-latest' }}
+    # GitHub-hosted: a relay that only reads a step outcome should not hold a
+    # pool slot. See `text-gates`.
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     needs: live-path-gates
     if: always()
@@ -959,3 +929,190 @@ jobs:
           cargo fuzz run path_can_access -- -max_total_time=30
           cargo fuzz run permission_serde -- -max_total_time=30
           cargo fuzz run workload_api_command -- -max_total_time=30
+
+  verify-strict:
+    name: Ed25519 verify_strict gate (M-3)
+    # GitHub-hosted on purpose: see `text-gates`. A relay on the pool costs a
+    # slot and undoes the consolidation.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: text-gates
+    if: always()
+    steps:
+      - name: Report
+        env:
+          JOB: ${{ needs.text-gates.result }}
+          STEP: ${{ needs.text-gates.outputs.verify_strict }}
+        run: |
+          case "$JOB" in skipped) exit 0;; success) ;; *) echo "::error::text-gates job: $JOB"; exit 1;; esac
+          case "$STEP" in success|skipped) exit 0;; *) echo "::error::verify_strict: $STEP (see 'Text gates (one pod)' → 'Forbid non-strict dalek .verify(...) on trust paths')"; exit 1;; esac
+
+  sandbox-trusted-base-gate:
+    name: Sandbox trusted-base gate
+    # GitHub-hosted on purpose: see `text-gates`. A relay on the pool costs a
+    # slot and undoes the consolidation.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: text-gates
+    if: always()
+    steps:
+      - name: Report
+        env:
+          JOB: ${{ needs.text-gates.result }}
+          STEP: ${{ needs.text-gates.outputs.sandbox_trusted_base }}
+        run: |
+          case "$JOB" in skipped) exit 0;; success) ;; *) echo "::error::text-gates job: $JOB"; exit 1;; esac
+          case "$STEP" in success|skipped) exit 0;; *) echo "::error::sandbox_trusted_base: $STEP (see 'Text gates (one pod)' → 'Every pin names a real test; the unpinned set may only shrink')"; exit 1;; esac
+
+  failclosed-verifier-gate:
+    name: Fail-closed verifier gate
+    # GitHub-hosted on purpose: see `text-gates`. A relay on the pool costs a
+    # slot and undoes the consolidation.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: text-gates
+    if: always()
+    steps:
+      - name: Report
+        env:
+          JOB: ${{ needs.text-gates.result }}
+          STEP: ${{ needs.text-gates.outputs.failclosed }}
+        run: |
+          case "$JOB" in skipped) exit 0;; success) ;; *) echo "::error::text-gates job: $JOB"; exit 1;; esac
+          case "$STEP" in success|skipped) exit 0;; *) echo "::error::failclosed: $STEP (see 'Text gates (one pod)' → 'Forbid a verifier that reports success where it cannot check')"; exit 1;; esac
+
+  mediation-gate:
+    name: Mediation backstop gate (North Star)
+    # GitHub-hosted on purpose: see `text-gates`. A relay on the pool costs a
+    # slot and undoes the consolidation.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: text-gates
+    if: always()
+    steps:
+      - name: Report
+        env:
+          JOB: ${{ needs.text-gates.result }}
+          STEP: ${{ needs.text-gates.outputs.mediation }}
+        run: |
+          case "$JOB" in skipped) exit 0;; success) ;; *) echo "::error::text-gates job: $JOB"; exit 1;; esac
+          case "$STEP" in success|skipped) exit 0;; *) echo "::error::mediation: $STEP (see 'Text gates (one pod)' → 'Forbid raw agent-path effect primitives outside the discharge-gated API')"; exit 1;; esac
+
+  north-star-ledger:
+    name: The North Star status table cannot outrun its wiring
+    # GitHub-hosted on purpose: see `text-gates`. A relay on the pool costs a
+    # slot and undoes the consolidation.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: text-gates
+    if: always()
+    steps:
+      - name: Report
+        env:
+          JOB: ${{ needs.text-gates.result }}
+          STEP: ${{ needs.text-gates.outputs.north_star }}
+        run: |
+          case "$JOB" in skipped) exit 0;; success) ;; *) echo "::error::text-gates job: $JOB"; exit 1;; esac
+          case "$STEP" in success|skipped) exit 0;; *) echo "::error::north_star: $STEP (see 'Text gates (one pod)' → 'Every status row is earned, evidenced, and uncontradicted')"; exit 1;; esac
+
+  extracted-callsites:
+    name: Extracted predicates have live call sites (C8)
+    # GitHub-hosted on purpose: see `text-gates`. A relay on the pool costs a
+    # slot and undoes the consolidation.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: text-gates
+    if: always()
+    steps:
+      - name: Report
+        env:
+          JOB: ${{ needs.text-gates.result }}
+          STEP: ${{ needs.text-gates.outputs.extracted_callsites }}
+        run: |
+          case "$JOB" in skipped) exit 0;; success) ;; *) echo "::error::text-gates job: $JOB"; exit 1;; esac
+          case "$STEP" in success|skipped) exit 0;; *) echo "::error::extracted_callsites: $STEP (see 'Text gates (one pod)' → 'Every extracted predicate's enforcement is still wired')"; exit 1;; esac
+
+  task-compiler-offline:
+    name: The task compiler is offline by construction
+    # GitHub-hosted on purpose: see `text-gates`. A relay on the pool costs a
+    # slot and undoes the consolidation.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: text-gates
+    if: always()
+    steps:
+      - name: Report
+        env:
+          JOB: ${{ needs.text-gates.result }}
+          STEP: ${{ needs.text-gates.outputs.task_compiler }}
+        run: |
+          case "$JOB" in skipped) exit 0;; success) ;; *) echo "::error::text-gates job: $JOB"; exit 1;; esac
+          case "$STEP" in success|skipped) exit 0;; *) echo "::error::task_compiler: $STEP (see 'Text gates (one pod)' → 'No network crate in its dependency tables, no socket type in its sources')"; exit 1;; esac
+
+  ingest-hash-gate:
+    name: No-unwitnessed-ingest gate (InputsAuthorized)
+    # GitHub-hosted on purpose: see `text-gates`. A relay on the pool costs a
+    # slot and undoes the consolidation.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: text-gates
+    if: always()
+    steps:
+      - name: Report
+        env:
+          JOB: ${{ needs.text-gates.result }}
+          STEP: ${{ needs.text-gates.outputs.ingest_hash }}
+        run: |
+          case "$JOB" in skipped) exit 0;; success) ;; *) echo "::error::text-gates job: $JOB"; exit 1;; esac
+          case "$STEP" in success|skipped) exit 0;; *) echo "::error::ingest_hash: $STEP (see 'Text gates (one pod)' → 'Forbid non-hashing agent-path ingest observes (content-address every input)')"; exit 1;; esac
+
+  kani-divergence-gate:
+    name: cfg(kani) divergences are inventoried and ratcheted
+    # GitHub-hosted on purpose: see `text-gates`. A relay on the pool costs a
+    # slot and undoes the consolidation.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: text-gates
+    if: always()
+    steps:
+      - name: Report
+        env:
+          JOB: ${{ needs.text-gates.result }}
+          STEP: ${{ needs.text-gates.outputs.kani_divergence }}
+        run: |
+          case "$JOB" in skipped) exit 0;; success) ;; *) echo "::error::text-gates job: $JOB"; exit 1;; esac
+          case "$STEP" in success|skipped) exit 0;; *) echo "::error::kani_divergence: $STEP (see 'Text gates (one pod)' → 'Every cfg(kani) site is listed and justified; the total only shrinks')"; exit 1;; esac
+
+  sealed-home-gate:
+    name: Sealed-home integrity gate (North Star)
+    # GitHub-hosted on purpose: see `text-gates`. A relay on the pool costs a
+    # slot and undoes the consolidation.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: text-gates
+    if: always()
+    steps:
+      - name: Report
+        env:
+          JOB: ${{ needs.text-gates.result }}
+          STEP: ${{ needs.text-gates.outputs.sealed_home }}
+        run: |
+          case "$JOB" in skipped) exit 0;; success) ;; *) echo "::error::text-gates job: $JOB"; exit 1;; esac
+          case "$STEP" in success|skipped) exit 0;; *) echo "::error::sealed_home: $STEP (see 'Text gates (one pod)' → 'Forbid raw effect primitives outside the sealed RealEffects home')"; exit 1;; esac
+
+  declassify-governor-keys-sealed:
+    name: Governor trusted-key set is not workload-writable
+    # GitHub-hosted on purpose: see `text-gates`. A relay on the pool costs a
+    # slot and undoes the consolidation.
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: text-gates
+    if: always()
+    steps:
+      - name: Report
+        env:
+          JOB: ${{ needs.text-gates.result }}
+          STEP: ${{ needs.text-gates.outputs.governor_keys }}
+        run: |
+          case "$JOB" in skipped) exit 0;; success) ;; *) echo "::error::text-gates job: $JOB"; exit 1;; esac
+          case "$STEP" in success|skipped) exit 0;; *) echo "::error::governor_keys: $STEP (see 'Text gates (one pod)' → 'set_trusted_keys has no caller outside kernel construction')"; exit 1;; esac

--- a/ci/fly-runner/README.md
+++ b/ci/fly-runner/README.md
@@ -58,7 +58,7 @@ checkout, toolchain or executable); a gate pool Machine has no volume.
 | pool | label | Machine | jobs |
 |---|---|---|---|
 | build | `nucleus-fly-build` | performance-8x, 32 GB, one volume each (8 × 40 GB + 8 × 20 GB); size 16, standby 16 | everything on `CI_BUILD_RUNNER`: workspace tests, clippy, live-path gates, hack, llvm-cov, dylint, the A2A example (24 `runs-on` sites) |
-| gate | `nucleus-fly-gate` | shared-cpu-8x, 16 GB, no volume; size 40, standby 40 | everything on `CI_RUNNER` (54 sites), opt-in |
+| gate | `nucleus-fly-gate` | shared-cpu-8x, 16 GB, no volume; size 40, standby 40 | everything on `CI_RUNNER` (40 sites), opt-in |
 
 Routing is the two repository variables the workflows already read:
 
@@ -70,8 +70,15 @@ gh variable set CI_RUNNER --repo coproduct-opensource/nucleus --body nucleus-fly
 
 The build pool alone removes the jobs that hold a hosted slot for 6 to 12 minutes; the short
 jobs left on hosted runners then flow. The gate pool takes the rest. Jobs that hard-code
-`ubuntu-latest` (48 sites) or `ubuntu-24.04` (16) stay hosted; those are the ones that need
-Docker, CodeQL or a hosted-only tool. The image here is a Rust build image (pinned
+`ubuntu-latest` (63 sites) or `ubuntu-24.04` (16) stay hosted; those are the ones that need
+Docker, CodeQL or a hosted-only tool.
+
+The gate count fell 54 → 40 on 2026-09-11: `ci.yml`'s eleven grep-only gate jobs were folded
+into one `text-gates` pod, and the fifteen relay jobs that report their outcomes back to each
+required context moved to hosted runners. A relay does nothing but read a step outcome, so on
+a public repository — where hosted minutes are free and unmetered — holding a gate-pool slot
+for one buys nothing. That is also why the earlier build-once consolidation (#2635) won on
+build time but not on slot acquisitions: its four relays stayed on the pool. The image here is a Rust build image (pinned
 toolchain, wasm target, clippy, rustfmt, nextest, sccache, just, node via `setup-node`,
 python3); a job on `CI_RUNNER` that needs elan, aeneas or kani installs it in-job today on
 hosted runners and keeps doing so here.

--- a/ci/inline-gates.txt
+++ b/ci/inline-gates.txt
@@ -11,14 +11,19 @@
 # Regenerate with `cargo xtask ci-spec inline-gates > ci/inline-gates.txt`
 # (annotations are carried forward).
 #
-# UNCOVERED_CEILING = 80
+# UNCOVERED_CEILING = 90
 #
-# 2026-09-06: 71 → 80. The build-once consolidation (#2635) reports each of the
-# eight consolidated steps back to its required context through a thin relay
-# step (`case $JOB/$STEP`); each relay is a new inline gate with no falsifier of
-# its own — the step it relays keeps its falsifier under its own key. The ninth
-# is kani-spawn-boundary.yml::kani-argv, an existing inline gate the inventory
-# had never listed. Shrinks again when the relays get a self-test.
+# 2026-09-11: 80 → 90. The grep-only consolidation folds eleven single-script
+# gate jobs into `ci.yml`'s `text-gates` and relays each outcome back to its own
+# required context through a thin `case $JOB/$STEP` step. Each relay is a new
+# inline gate with no falsifier of its own; the SCRIPT it relays keeps its
+# falsifier under its own key in scripts/check-gates-can-fail.sh. Exactly the
+# shape of 2026-09-06's 71 → 80, and for the same reason.
+#
+# The three entries this regeneration would also have absorbed
+# (action-smoke-test.yml::dry-run and two podlist-probe steps) are PRE-EXISTING
+# drift and are deliberately left out: a ratchet that quietly swallows
+# unrelated debt is not a ratchet.
 
 a2a-tck.yml::tck::Start the target on :9999 | UNCOVERED: no falsifier yet
 action-smoke-test.yml::dry-run::Dry-run: safe_pr_fixer profile | UNCOVERED: no falsifier yet
@@ -60,6 +65,17 @@ ci.yml::declassify-sink-scope-enforced::Report | UNCOVERED: relay of a consolida
 ci.yml::cross-pod-lineage::Report | UNCOVERED: relay of a consolidated step's outcome to this required context; the relayed step carries the falsifier
 ci.yml::c1-inbound-fences-enforced::Report | UNCOVERED: relay of a consolidated step's outcome to this required context; the relayed step carries the falsifier
 ci.yml::gates-can-fail::Report | UNCOVERED: relay of a consolidated step's outcome to this required context; the relayed step carries the falsifier
+ci.yml::verify-strict::Report | UNCOVERED: no falsifier yet
+ci.yml::sandbox-trusted-base-gate::Report | UNCOVERED: no falsifier yet
+ci.yml::failclosed-verifier-gate::Report | UNCOVERED: no falsifier yet
+ci.yml::mediation-gate::Report | UNCOVERED: no falsifier yet
+ci.yml::north-star-ledger::Report | UNCOVERED: no falsifier yet
+ci.yml::extracted-callsites::Report | UNCOVERED: no falsifier yet
+ci.yml::task-compiler-offline::Report | UNCOVERED: no falsifier yet
+ci.yml::ingest-hash-gate::Report | UNCOVERED: no falsifier yet
+ci.yml::kani-divergence-gate::Report | UNCOVERED: no falsifier yet
+ci.yml::sealed-home-gate::Report | UNCOVERED: no falsifier yet
+ci.yml::declassify-governor-keys-sealed::Report | UNCOVERED: no falsifier yet
 ck-policy-aeneas.yml::ck-policy-aeneas::Verify generated Lean matches committed (drift gate) | UNCOVERED: no falsifier yet
 ck-policy-aeneas.yml::ck-policy-aeneas::Ban sorry / admit / native_decide in our proof file | UNCOVERED: no falsifier yet
 ck-policy-lean.yml::ck-policy-lean::Ban sorry / admit / native_decide / sorryAx in ck-policy Lean | UNCOVERED: no falsifier yet


### PR DESCRIPTION
## Measured first

On #2848, across its `pull_request` and `merge_group` runs, eleven jobs in `ci.yml` each took a pod to run **one** `scripts/check-*.sh` over the checked-out tree:

> **2,297 seconds of slot wait for 178 seconds of work.**

Thirteen times more waiting than working, to run eleven greps.

Separating slot wait from *dependency* wait mattered: a job with `needs:` looks like it queued for six minutes when it was waiting on its upstream, which overstates contention by ~40%. The real figure for `ci.yml` is 53 min of slot wait on the PR run and 87 min in the merge group. These eleven are 38 of that 140.

## What changed

One `text-gates` job checks out once and runs all eleven as `continue-on-error` steps. Each outcome relays back to its own required context through a thin `case $JOB/$STEP` job.

**No context name changes** — `ci/required-checks.txt` and branch protection are untouched. Same shape as #2635's live-path consolidation.

## The relays run on GitHub-hosted, which is the whole trick

#2635's relays ask for `vars.CI_RUNNER`, so each takes a pool slot exactly like the job it replaced. That consolidation won on **build** time — one cargo build instead of three — and broke even on slot acquisitions.

There is no build to share here. These are greps. Eleven relays on the pool would have given back everything the consolidation saves, and the change would have been a net loss of one job. On hosted runners they cost the pool nothing, and this repo is public, where hosted minutes are free and unmetered.

The four existing live-path relays move for the same reason, in the same diff — they are `case`/`echo` steps holding a build-pool slot.

**Pool acquisitions for these gates: 11 → 1 per run. 22 → 2 across a merged PR's two runs.**

## What may ride along

Read-only text gates only. All eleven scripts were checked for tree mutation, including the two that shell out to python — both only read. A gate that *perturbs* files cannot share a pod with gates that read them, which is why `check-gates-can-fail.sh` runs last inside `live-path-gates` and is not here.

## Fail-closed

An empty `STEP` — checkout failed, job died before the step ran — hits the `*)` arm and reds. Only an explicitly `skipped` job passes, and I3 already forbids a required context being skippable under `merge_group`.

## The ratchet

`ci/inline-gates.txt`: **80 → 90**. Each relay is a new inline gate with no falsifier of its own; the *script* it relays keeps its falsifier under its own key in `check-gates-can-fail.sh`. Exactly 2026-09-06's 71 → 80.

Regenerating would also have absorbed three **pre-existing** drift entries (`action-smoke-test.yml::dry-run` and two `podlist-probe` steps). They are deliberately left out and noted in the file: a ratchet that quietly swallows unrelated debt is not a ratchet.

## Verified locally

```
check-ci-spec.sh          ok: every invariant holds
check-gates-can-fail.sh   35 gate scripts found, 37 probed, 0 unaccounted
                          OK: every probed gate REDs on its own subject and GREENs when restored
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016t7JSuCtg4dC54HZjFgBjr