### PR TITLE
The shadow gate's timeout fires before its job dies, and a red says what it means

### DIFF
--- a/.github/actions/gatehouse/gatehouse.sh
+++ b/.github/actions/gatehouse/gatehouse.sh
@@ -77,8 +77,25 @@ jq -n --arg plan "$PLAN" --arg kid "$KID" --arg sk "$SK" --arg rd "$RUNNER_DIGES
     credential_tier: "developer", runner_digest: $rd, binding: null}' > "$W/job.json"
 
 # ── 4. The runner: materialize, run, sign ──────────────────────────────────────────────────
-set +e; "$RUNNER" "$W/job.json" "$W/receipt.json"; RC=$?; set -e
-case "$RC" in 0) VERDICT=held ;; 1) VERDICT=failed ;; *) die "the runner errored (exit $RC): the gate could not be run" ;; esac
+# An OUTER deadline on the runner itself, above the gate's own `timeout_s`.
+#
+# The gate's timeout bounds the COMMAND. It says nothing about the runner
+# hanging anywhere else — materializing the scope, reading a pipe, signing —
+# and on 2026-09-11 exactly that happened: a deadlock in the runner's log
+# reader (gatehouse F-100) hung every shadow job until GitHub cancelled it,
+# which produces no receipt, no log and no diagnosis. `timeout` turns that into
+# exit 124 and the message below.
+#
+# The slack is deliberate: the runner must be allowed to hit its own deadline,
+# kill the command and write an honest `errored` receipt before this fires.
+set +e; timeout --signal=TERM --kill-after=30 "$(( GH_TIMEOUT + 120 ))" \
+  "$RUNNER" "$W/job.json" "$W/receipt.json"; RC=$?; set -e
+case "$RC" in
+  0) VERDICT=held ;;
+  1) VERDICT=failed ;;
+  124|137) die "the runner did not finish within $(( GH_TIMEOUT + 120 ))s and was killed: it hung somewhere outside the command's own timeout, so there is no receipt to show" ;;
+  *) die "the runner errored (exit $RC): the gate could not be run" ;;
+esac
 say "gate $NAME: $VERDICT"
 
 # ── 5. The receipt into the hosted log, and verified here against the tenant's trust ───────

--- a/.github/workflows/gatehouse-shadow.yml
+++ b/.github/workflows/gatehouse-shadow.yml
@@ -28,7 +28,15 @@ permissions:
 
 jobs:
   shadow:
-    name: "The ${{ matrix.gate }} gate, run the gatehouse way, agrees with the GitHub check (shadow, informational)"
+    # The name says what a RED means, because this check never fails on
+    # disagreement — only when the loop could not run at all. Named "agrees
+    # with the GitHub check", sixteen red shadows on 2026-09-11 read as sixteen
+    # disagreements when every one of them meant "could not look". gatehouse's
+    # verifier is three-valued (Verified / Refuted / CouldNotLook) and a GitHub
+    # check has two states, so the name is the only place that distinction can
+    # survive. ADR 0007 A-2: "I could not look" is never "I looked and it was
+    # fine" — and it is not "I looked and it was wrong" either.
+    name: "The ${{ matrix.gate }} gate, run the gatehouse way (shadow, informational; red = could not look, never disagreement)"
     runs-on: ubuntu-latest
     timeout-minutes: 45
     strategy:
@@ -115,7 +123,15 @@ jobs:
           run: ${{ matrix.github }}
           name: ${{ matrix.gate }}
           scope: ${{ matrix.scope }}
-          timeout: "2700"
+          # STRICTLY BELOW the job's 45 minutes, and that is the whole point.
+          # It was 2700 — the same 2,700 seconds as `timeout-minutes: 45` — so
+          # the runner's own deadline could never fire first: a hung gate could
+          # only ever end as a cancelled job, with no receipt, no log and
+          # nothing saying why. Measured 2026-09-11, when a deadlock in the
+          # runner (gatehouse F-100) did exactly that on sixteen open pull
+          # requests. A gate's own timeout must fire before its job is killed,
+          # or the gate cannot report its own failure.
+          timeout: "2100"
           bin-dir: gatehouse/target/debug
           control-url: ${{ vars.GATEHOUSE_CONTROL_URL || 'https://gatehouse-controld.fly.dev' }}
       - name: The agreement line


### PR DESCRIPTION
The nucleus half of gatehouse **F-100**. The gatehouse runner deadlocked on any command writing more to stderr than a pipe buffer holds — which is every cargo command there is — and hung all three shadow legs on **sixteen** open PRs for 45 minutes each.

The deadlock is fixed in gatehouse (one reader thread per stream; 9-test suite now runs in 1.21s, was hitting a 10s timeout). These are the three things on *this* side that turned a bug into an **undiagnosable** one.

### 1. The timeout could not fire

`timeout: "2700"` against the job's own `timeout-minutes: 45` is the same 2,700 seconds, so the runner's deadline could never win the race. The only possible outcome was a cancelled job — no receipt, no log, nothing saying why. Now `2100`, strictly below.

### 2. The runner had no outer deadline at all

The gate's `timeout_s` bounds the **command**. It says nothing about the runner hanging elsewhere — materializing the scope, reading a pipe, signing — which is exactly where it hung.

`timeout --signal=TERM --kill-after=30` at `GH_TIMEOUT + 120` turns that into exit 124 and a message that names it. The slack is deliberate: the runner must be allowed to hit its own deadline, kill the command and write an honest `errored` receipt before this fires.

### 3. Red meant "could not look" and the name said "agrees"

This check never fails on disagreement — only when the loop could not run at all. Named *"agrees with the GitHub check"*, sixteen reds read as sixteen disagreements when every one meant "could not look". I read them that way myself before checking.

gatehouse's verifier is scrupulously three-valued (`Verified` / `Refuted` / `CouldNotLook`); a GitHub check has two states. The name is the only place that distinction can survive, so it now carries it.

ADR 0007 A-2: *"I could not look" is never "I looked and it was fine"* — and it is not "I looked and it was wrong" either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016t7JSuCtg4dC54HZjFgBjr