### PR TITLE
The crate that decides receipt reuse declares it cannot panic

### DIFF
--- a/crates/nucleus-action-key/src/census.rs
+++ b/crates/nucleus-action-key/src/census.rs
@@ -65,16 +65,20 @@ pub fn run(root: &Path) -> Result<Census> {
     let mut census = Census::default();
     for context in &model.ledger.contexts {
         let outcome = match derive::key_for(root, &model, context) {
-            Ok(Ok(key)) => {
-                let inputs = derive::inputs_for(root, &model, context)?
-                    .expect("a context that keyed cannot refuse on the next call");
-                Outcome::Keyed {
+            // One call, not two. This derived the key and then re-derived the
+            // inputs to count them, with an `expect` asserting the second call
+            // agreed with the first — an assumption about determinism enforced
+            // by a panic. `inputs_for` gives both, so there is nothing to
+            // assume.
+            Ok(Ok(key)) => match derive::inputs_for(root, &model, context)? {
+                Ok(inputs) => Outcome::Keyed {
                     context: context.clone(),
                     key,
                     reads: inputs.read_set.len(),
                     gate_files: inputs.gate.len(),
-                }
-            }
+                },
+                Err(refusal) => Outcome::Refused(refusal),
+            },
             Ok(Err(refusal)) => Outcome::Refused(refusal),
             Err(e) => Outcome::Unmeasured {
                 context: context.clone(),

--- a/crates/nucleus-action-key/src/derive.rs
+++ b/crates/nucleus-action-key/src/derive.rs
@@ -54,17 +54,24 @@ fn matches(pattern: &str, path: &str) -> Option<bool> {
 /// Segment matcher. `**` consumes zero or more segments, which is why this is
 /// recursive rather than a zip.
 fn match_segments(pat: &[&str], seg: &[&str]) -> bool {
-    match pat.first() {
-        None => seg.is_empty(),
-        Some(&"**") => {
-            // Zero or more segments. GitHub treats a trailing `**` as "this
-            // directory and everything under it".
-            (0..=seg.len()).any(|i| match_segments(&pat[1..], &seg[i..]))
-        }
-        Some(p) => match seg.first() {
+    // `split_first` rather than `first()` + `[1..]`: the tail comes back with
+    // the head, so there is no second, unchecked way to get it wrong. A panic
+    // here would be a key derivation that could not finish, which this crate
+    // must never confuse with a key that says "no match".
+    let Some((head, pat_rest)) = pat.split_first() else {
+        return seg.is_empty();
+    };
+    if *head == "**" {
+        // Zero or more segments. GitHub treats a trailing `**` as "this
+        // directory and everything under it".
+        return (0..=seg.len()).any(|i| match seg.get(i..) {
+            Some(tail) => match_segments(pat_rest, tail),
             None => false,
-            Some(s) => match_one(p, s) && match_segments(&pat[1..], &seg[1..]),
-        },
+        });
+    }
+    match seg.split_first() {
+        None => false,
+        Some((s, seg_rest)) => match_one(head, s) && match_segments(pat_rest, seg_rest),
     }
 }
 
@@ -72,35 +79,47 @@ fn match_segments(pat: &[&str], seg: &[&str]) -> bool {
 /// non-`/` characters.
 fn match_one(pat: &str, seg: &str) -> bool {
     let parts: Vec<&str> = pat.split('*').collect();
-    if parts.len() == 1 {
+    // `split_first`/`split_last` again: the interior is what is left over,
+    // which is the same fact as "not the first and not the last" without a
+    // second expression of it that can disagree. The old
+    // `&parts[1..parts.len().saturating_sub(1)]` was that second expression.
+    let Some((first, after_first)) = parts.split_first() else {
         return pat == seg;
-    }
+    };
+    let Some((last, interior)) = after_first.split_last() else {
+        // No `*` at all: one part, so the pattern is literal.
+        return pat == seg;
+    };
+
     let mut rest = seg;
     // The first part must be a prefix (unless the pattern starts with `*`).
-    if let Some(first) = parts.first()
-        && !first.is_empty()
-    {
+    if !first.is_empty() {
         match rest.strip_prefix(*first) {
             Some(r) => rest = r,
             None => return false,
         }
     }
     // The last must be a suffix (unless the pattern ends with `*`).
-    if let Some(last) = parts.last()
-        && !last.is_empty()
-    {
+    if !last.is_empty() {
         match rest.strip_suffix(*last) {
-            Some(r) if rest.len() >= last.len() => rest = r,
-            _ => return false,
+            Some(r) => rest = r,
+            None => return false,
         }
     }
     // Interior parts must appear in order.
-    for mid in &parts[1..parts.len().saturating_sub(1)] {
+    for mid in interior {
         if mid.is_empty() {
             continue;
         }
-        match rest.find(mid) {
-            Some(i) => rest = &rest[i + mid.len()..],
+        // `find` returns a byte offset at a char boundary and `mid` is a
+        // substring from there, so the sum is a boundary too — but slicing on
+        // an arithmetic result is exactly the shape that panics when the
+        // reasoning is wrong, so take the remainder by length instead.
+        match rest.find(mid).and_then(|i| {
+            rest.get(i..)
+                .and_then(|from_match| from_match.get(mid.len()..))
+        }) {
+            Some(after) => rest = after,
             None => return false,
         }
     }
@@ -240,10 +259,15 @@ pub fn inputs_for(root: &Path, model: &Model, context: &str) -> Result<Result<In
     // fires, and the noop reports the same context green in seconds. So the
     // real twin is the gate, and its filter is the declared read-set. Dropping
     // the noop half here is the difference between 11 refusals and 11 keys.
+    // `get` rather than `[]` throughout: `producers` hands back indices into
+    // `model.workflows`, and this crate must never turn a stale index into a
+    // panic. A panic here is a key derivation that could not finish, and the
+    // whole design turns on never confusing that with a derivation that
+    // finished and said "no key".
     let real: Vec<_> = all
         .iter()
         .copied()
-        .filter(|(wi, _)| !model.workflows[*wi].is_noop())
+        .filter(|(wi, _)| model.workflows.get(*wi).is_some_and(|w| !w.is_noop()))
         .collect();
     let producers = if real.is_empty() { all.clone() } else { real };
 
@@ -259,18 +283,31 @@ pub fn inputs_for(root: &Path, model: &Model, context: &str) -> Result<Result<In
                 context: context.to_string(),
                 producers: producers
                     .iter()
-                    .map(|(wi, ji)| {
-                        format!(
-                            "{}::{}",
-                            model.workflows[*wi].path, model.workflows[*wi].jobs[*ji].id
-                        )
+                    .map(|(wi, ji)| match model.workflows.get(*wi) {
+                        Some(w) => match w.jobs.get(*ji) {
+                            Some(j) => format!("{}::{}", w.path, j.id),
+                            None => format!("{}::<job {ji} is gone>", w.path),
+                        },
+                        None => format!("<workflow {wi} is gone>::<job {ji}>"),
                     })
                     .collect(),
             }));
         }
     }
-    let (wi, _) = producers[0];
-    let w = &model.workflows[wi];
+    // The `match` above established exactly one producer, but "established by
+    // an earlier branch" is the reasoning that `[0]` panics on when someone
+    // edits the branch. Ask for it.
+    let Some(&(wi, _)) = producers.first() else {
+        return Ok(Err(Refusal::NoProducer {
+            context: context.to_string(),
+        }));
+    };
+    let Some(w) = model.workflows.get(wi) else {
+        anyhow::bail!(
+            "context {context:?} names workflow index {wi}, which the model does not have: the \
+             model changed under the index and a key derived from it would be about nothing"
+        );
+    };
 
     let Some(filter) = filter_of(w) else {
         return Ok(Err(Refusal::Unfiltered {

--- a/crates/nucleus-action-key/src/lib.rs
+++ b/crates/nucleus-action-key/src/lib.rs
@@ -68,6 +68,27 @@
 //! it away.
 
 #![forbid(unsafe_code)]
+// TOTALITY: a function whose signature says `-> T` and panics is lying about
+// its type. All seven lints, denied for the shipped build only — `assert!` IS
+// a panic, so denying inside `#[cfg(test)]` would forbid the thing tests are
+// made of. Measured zero of all seven before adding this, per `clippy.toml`'s
+// rule that an entry is added only when the tree is already clean of it.
+//
+// It matters more here than in most crates: this one decides whether a receipt
+// may be REUSED. A panic in the key derivation is a gate that could not look,
+// and the whole design turns on never confusing that with a gate that looked.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo
+    )
+)]
 
 use sha2::{Digest, Sha256};
 

--- a/crates/nucleus-action-key/src/main.rs
+++ b/crates/nucleus-action-key/src/main.rs
@@ -1,5 +1,27 @@
 //! `nucleus-action-key` — derive a CI gate's receipt key, or say why it has none.
 
+// TOTALITY: a function whose signature says `-> T` and panics is lying about
+// its type. All seven lints, denied for the shipped build only — `assert!` IS
+// a panic, so denying inside `#[cfg(test)]` would forbid the thing tests are
+// made of. Measured zero of all seven before adding this, per `clippy.toml`'s
+// rule that an entry is added only when the tree is already clean of it.
+//
+// It matters more here than in most crates: this one decides whether a receipt
+// may be REUSED. A panic in the key derivation is a gate that could not look,
+// and the whole design turns on never confusing that with a gate that looked.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo
+    )
+)]
+
 use anyhow::Result;
 use nucleus_action_key::census::{self, Outcome};
 use std::path::PathBuf;


### PR DESCRIPTION
The scorecard caught a regression **I caused**. #2853 added `nucleus-action-key`, which took `tot`'s population from 80 crates to 81 without declaring itself: **22/81 = 27.16% against a floor of 27.50%**.

The two-pin ratchet working exactly as designed — a floor alone would have rewarded deleting the obligation; the population pin caught the ratio falling at constant debt.

## Discharged, not lowered

The crate now denies all seven totality lints for the shipped build, and twelve real panic paths were removed to earn it:

| where | was | now |
|---|---|---|
| `derive.rs` | `&pat[1..]`, `&seg[i..]`, `&parts[1..len-1]`, `&rest[i + len..]`, `producers[0]` | `split_first` / `split_last` / `get` |
| `derive.rs` | `model.workflows[wi]`, `.jobs[ji]` | `get`, with a bail and a named fallback |
| `census.rs` | an `expect` asserting a second `inputs_for` call agreed with the first | one call returning both |

## Why it matters more here than in most crates

This crate decides whether a receipt may be **reused**. A panic in the key derivation is a gate that *could not look*, and the whole design turns on never confusing that with a gate that *looked* — the same A-2 distinction the verifier keeps three-valued. An index that panics collapses those two into one.

Two of the fixes are not mechanical:

- `&parts[1..parts.len().saturating_sub(1)]` was a **second expression** of "the interior parts", able to disagree with the first. `split_first` then `split_last` leaves the interior as what remains, so there is nothing to disagree.
- The `expect` encoded an assumption about determinism **enforced by a panic**. Calling once removes the assumption rather than asserting it.

## Unchanged behaviour

Census still reports `48 required context(s): 11 keyed, 37 refused, 0 unmeasured`; all ten tests pass; clippy clean under the declaration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016t7JSuCtg4dC54HZjFgBjr