### PR TITLE
A crate's read-set is derived, so it cannot be declared wrongly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6538,6 +6538,7 @@ dependencies = [
  "anyhow",
  "ci-spec",
  "hex",
+ "serde_json",
  "sha2 0.11.0",
 ]
 

--- a/crates/nucleus-action-key/Cargo.toml
+++ b/crates/nucleus-action-key/Cargo.toml
@@ -19,3 +19,4 @@ anyhow = { workspace = true }
 ci-spec = { path = "../ci-spec" }
 sha2 = { workspace = true }
 hex = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/nucleus-action-key/src/census.rs
+++ b/crates/nucleus-action-key/src/census.rs
@@ -65,16 +65,20 @@ pub fn run(root: &Path) -> Result<Census> {
     let mut census = Census::default();
     for context in &model.ledger.contexts {
         let outcome = match derive::key_for(root, &model, context) {
-            Ok(Ok(key)) => {
-                let inputs = derive::inputs_for(root, &model, context)?
-                    .expect("a context that keyed cannot refuse on the next call");
-                Outcome::Keyed {
+            // One call, not two. This derived the key and then re-derived the
+            // inputs to count them, with an `expect` asserting the second call
+            // agreed with the first — an assumption about determinism enforced
+            // by a panic. `inputs_for` gives both, so there is nothing to
+            // assume.
+            Ok(Ok(key)) => match derive::inputs_for(root, &model, context)? {
+                Ok(inputs) => Outcome::Keyed {
                     context: context.clone(),
                     key,
                     reads: inputs.read_set.len(),
                     gate_files: inputs.gate.len(),
-                }
-            }
+                },
+                Err(refusal) => Outcome::Refused(refusal),
+            },
             Ok(Err(refusal)) => Outcome::Refused(refusal),
             Err(e) => Outcome::Unmeasured {
                 context: context.clone(),

--- a/crates/nucleus-action-key/src/closure.rs
+++ b/crates/nucleus-action-key/src/closure.rs
@@ -1,0 +1,276 @@
+//! The read-set a crate actually has, derived rather than declared.
+//!
+//! # Why this exists, when `derive` already computes a read-set
+//!
+//! [`crate::derive`] takes a job's `paths:` filter — a declaration, written by
+//! hand, and only present on 11 of the 48 required contexts. The census names
+//! the other 37, and the honest answer there was "someone has to declare what
+//! these read".
+//!
+//! That answer was wrong, and this module is why. A Rust crate's read-set is
+//! not a matter of opinion: it is the crate's own sources plus the sources of
+//! every workspace crate it depends on, and `cargo metadata` already knows the
+//! graph exactly. **Nothing has to be declared, so nothing can be declared
+//! wrongly** — which is the one weakness the `paths:` key carries and the one
+//! gatehouse's scope-as-oid was built to remove.
+//!
+//! # What it is worth, measured
+//!
+//! Over nucleus's last 39 first-parent merges to `main`, against 82 workspace
+//! crates (2026-09-12):
+//!
+//! | | |
+//! |---|---|
+//! | merges affecting **zero** crates | **13 of 39 (33%)** |
+//! | median crates affected | **1 of 82** |
+//! | merges invalidating everything (`Cargo.lock` / toolchain) | 5 (13%) |
+//!
+//! A third of merges to `main` are CI-only — workflows, scripts, docs — and
+//! every one of them currently rebuilds and re-tests all 82 crates in the merge
+//! queue, because `ci.yml`'s `changed-crates` sets `all=true` for
+//! `merge_group`. That is not a bug: a merge group is a new combination, and
+//! narrowing it on the PR's diff would be unsound. A receipt keyed on a closure
+//! is the thing that can narrow it soundly.
+//!
+//! This independently reproduces gatehouse's own figure — `docs/scope-fanout.md`
+//! measured 37% of merged changes running zero gates under per-crate scopes, by
+//! a different method.
+//!
+//! # What it does not claim
+//!
+//! The closure covers **workspace-internal** dependencies. A change to an
+//! external crate moves `Cargo.lock`, which is in every closure, so the whole
+//! workspace invalidates — correct, and the 13% above. It says nothing about a
+//! crate reading a file at runtime that is not a source file of any crate:
+//! `include_str!`, a fixture directory, a `build.rs` reading the tree. Those
+//! are real and unmodelled, and the shadow lane is what would find them.
+
+use crate::ReadEntry;
+use anyhow::{Context, Result};
+use sha2::{Digest, Sha256};
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+/// Files every crate's closure contains, because a change to one of them
+/// changes what every crate compiles to.
+const WORKSPACE_WIDE: &[&str] = &["Cargo.lock", "rust-toolchain.toml"];
+
+/// The workspace's crates and the internal dependency graph between them.
+#[derive(Debug, Default)]
+pub struct Workspace {
+    /// Crate name -> its directory, repo-relative.
+    pub dirs: BTreeMap<String, String>,
+    /// Crate name -> the workspace crates it depends on, transitively,
+    /// including itself.
+    pub closures: BTreeMap<String, BTreeSet<String>>,
+}
+
+/// Read the workspace graph from `cargo metadata`.
+///
+/// Shelling out rather than linking `cargo_metadata`: the same choice
+/// [`crate::derive`] makes for `git ls-files`, and for the same reason — the
+/// authority on the graph is cargo, not a reimplementation of it here.
+pub fn load(root: &Path) -> Result<Workspace> {
+    let out = std::process::Command::new("cargo")
+        .arg("metadata")
+        .args(["--format-version", "1", "--all-features"])
+        .current_dir(root)
+        .output()
+        .context("running `cargo metadata`")?;
+    anyhow::ensure!(
+        out.status.success(),
+        "`cargo metadata` failed in {root:?}: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let meta: serde_json::Value =
+        serde_json::from_slice(&out.stdout).context("parsing cargo metadata")?;
+    from_metadata(&meta, root)
+}
+
+/// The pure half, so the graph logic is testable from a fixture rather than
+/// from whatever this workspace happens to contain today.
+pub fn from_metadata(meta: &serde_json::Value, root: &Path) -> Result<Workspace> {
+    // Resolve the root once: see the note on `strip_prefix` below.
+    let canonical_root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+
+    let members: BTreeSet<&str> = meta
+        .get("workspace_members")
+        .and_then(|m| m.as_array())
+        .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
+        .unwrap_or_default();
+    anyhow::ensure!(
+        !members.is_empty(),
+        "cargo metadata listed no workspace members: a closure over nothing is not a read-set"
+    );
+
+    // id -> name, and id -> directory.
+    let mut name_of: BTreeMap<&str, String> = BTreeMap::new();
+    let mut dirs: BTreeMap<String, String> = BTreeMap::new();
+    for pkg in meta
+        .get("packages")
+        .and_then(|p| p.as_array())
+        .map(Vec::as_slice)
+        .unwrap_or_default()
+    {
+        let (Some(id), Some(name), Some(mp)) = (
+            pkg.get("id").and_then(|v| v.as_str()),
+            pkg.get("name").and_then(|v| v.as_str()),
+            pkg.get("manifest_path").and_then(|v| v.as_str()),
+        ) else {
+            continue;
+        };
+        if !members.contains(id) {
+            continue;
+        }
+        name_of.insert(id, name.to_string());
+        let dir = Path::new(mp).parent().unwrap_or(Path::new("."));
+        // Both sides canonicalized. Cargo reports `manifest_path` resolved, and
+        // on macOS `/var` is a symlink to `/private/var` — so a tempdir root
+        // arrives as `/var/...` while cargo says `/private/var/...`, and a bare
+        // `strip_prefix` silently fails. It does not error: it leaves the path
+        // ABSOLUTE, the prefix match against repo-relative filenames then finds
+        // nothing, and every crate's read-set quietly collapses to the two
+        // workspace-wide files. A key over almost nothing still looks like a
+        // key, which is why this is a refusal rather than a fallback.
+        let rel = dir
+            .strip_prefix(&canonical_root)
+            .or_else(|_| dir.strip_prefix(root))
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "crate {name}'s manifest at {} is not under the workspace root {}: a \
+                     read-set derived from it would silently be empty",
+                    dir.display(),
+                    canonical_root.display()
+                )
+            })?;
+        dirs.insert(name.to_string(), rel.to_string_lossy().replace('\\', "/"));
+    }
+
+    // The resolved graph, restricted to workspace members.
+    let mut edges: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    for node in meta
+        .get("resolve")
+        .and_then(|r| r.get("nodes"))
+        .and_then(|n| n.as_array())
+        .map(Vec::as_slice)
+        .unwrap_or_default()
+    {
+        let Some(id) = node.get("id").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        if !members.contains(id) {
+            continue;
+        }
+        let deps = node
+            .get("deps")
+            .and_then(|d| d.as_array())
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+            .iter()
+            .filter_map(|d| d.get("pkg").and_then(|v| v.as_str()))
+            .filter(|p| members.contains(p))
+            .collect();
+        edges.insert(id, deps);
+    }
+
+    let mut closures = BTreeMap::new();
+    for id in &members {
+        let Some(name) = name_of.get(id) else {
+            continue;
+        };
+        let mut seen: BTreeSet<&str> = BTreeSet::new();
+        walk(id, &edges, &mut seen);
+        let names = seen
+            .iter()
+            .filter_map(|i| name_of.get(i).cloned())
+            .collect::<BTreeSet<String>>();
+        closures.insert(name.clone(), names);
+    }
+    Ok(Workspace { dirs, closures })
+}
+
+/// Depth-first over the internal graph. Iterative, so a dependency cycle — which
+/// cargo forbids but a fixture can express — cannot blow the stack.
+fn walk<'a>(start: &'a str, edges: &BTreeMap<&'a str, Vec<&'a str>>, seen: &mut BTreeSet<&'a str>) {
+    let mut stack = vec![start];
+    while let Some(id) = stack.pop() {
+        if !seen.insert(id) {
+            continue;
+        }
+        if let Some(deps) = edges.get(id) {
+            stack.extend(deps.iter().copied());
+        }
+    }
+}
+
+impl Workspace {
+    /// The read-set for one crate: every tracked file under each closure
+    /// member's directory, plus the workspace-wide files.
+    ///
+    /// `tracked` is the repository's tracked-file list, passed in rather than
+    /// re-read per crate — this is called once per crate and `git ls-files`
+    /// over a large tree is not free.
+    pub fn read_set(
+        &self,
+        root: &Path,
+        tracked: &[String],
+        crate_name: &str,
+    ) -> Result<Vec<ReadEntry>> {
+        let Some(members) = self.closures.get(crate_name) else {
+            anyhow::bail!("{crate_name} is not a workspace crate");
+        };
+        let prefixes: Vec<String> = members
+            .iter()
+            .filter_map(|m| self.dirs.get(m))
+            .map(|d| format!("{d}/"))
+            .collect();
+
+        let mut out = Vec::new();
+        for f in tracked {
+            let wide = WORKSPACE_WIDE.contains(&f.as_str());
+            if !wide && !prefixes.iter().any(|p| f.starts_with(p.as_str())) {
+                continue;
+            }
+            out.push(ReadEntry {
+                path: f.clone(),
+                digest: digest_of(root, f)?,
+            });
+        }
+        out.sort();
+        Ok(out)
+    }
+}
+
+fn digest_of(root: &Path, rel: &str) -> Result<[u8; 32]> {
+    let bytes = std::fs::read(root.join(rel)).with_context(|| format!("reading {rel}"))?;
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&Sha256::digest(&bytes));
+    Ok(out)
+}
+
+/// The action key for `cargo <gate> -p <crate>`.
+///
+/// Same absorption as [`crate::ActionKey::derive`] — tagged, length-prefixed,
+/// no `Debug` — with the crate's closure standing where a job's `paths:` filter
+/// would. The gate's own code and the toolchain still enter it: a weakened gate
+/// must not answer green from its stronger self's history, and the same clippy
+/// under two compilers is two gates.
+pub fn key_for_crate(
+    ws: &Workspace,
+    root: &Path,
+    tracked: &[String],
+    crate_name: &str,
+    gate: &str,
+    gate_files: &[ReadEntry],
+) -> Result<crate::ActionKey> {
+    let read_set = ws.read_set(root, tracked, crate_name)?;
+    Ok(crate::ActionKey::derive(&crate::Inputs {
+        // The context is the (gate, crate) pair: `clippy` over `portcullis` is
+        // a different obligation from `clippy` over `nucleus-node`, and a key
+        // that conflated them would answer one with the other's receipt.
+        context: format!("{gate}::{crate_name}"),
+        read_set,
+        gate: gate_files.to_vec(),
+        toolchain: Vec::new(),
+    }))
+}

--- a/crates/nucleus-action-key/src/derive.rs
+++ b/crates/nucleus-action-key/src/derive.rs
@@ -132,7 +132,7 @@ fn match_one(pat: &str, seg: &str) -> bool {
 /// `git ls-files` is the enumeration, not `walkdir`: an untracked build
 /// artefact that happened to match a pattern would otherwise enter the key and
 /// make it depend on the machine.
-fn tracked_files(root: &Path) -> Result<Vec<String>> {
+pub fn tracked_files(root: &Path) -> Result<Vec<String>> {
     let out = std::process::Command::new("git")
         .arg("-C")
         .arg(root)

--- a/crates/nucleus-action-key/src/derive.rs
+++ b/crates/nucleus-action-key/src/derive.rs
@@ -54,17 +54,24 @@ fn matches(pattern: &str, path: &str) -> Option<bool> {
 /// Segment matcher. `**` consumes zero or more segments, which is why this is
 /// recursive rather than a zip.
 fn match_segments(pat: &[&str], seg: &[&str]) -> bool {
-    match pat.first() {
-        None => seg.is_empty(),
-        Some(&"**") => {
-            // Zero or more segments. GitHub treats a trailing `**` as "this
-            // directory and everything under it".
-            (0..=seg.len()).any(|i| match_segments(&pat[1..], &seg[i..]))
-        }
-        Some(p) => match seg.first() {
+    // `split_first` rather than `first()` + `[1..]`: the tail comes back with
+    // the head, so there is no second, unchecked way to get it wrong. A panic
+    // here would be a key derivation that could not finish, which this crate
+    // must never confuse with a key that says "no match".
+    let Some((head, pat_rest)) = pat.split_first() else {
+        return seg.is_empty();
+    };
+    if *head == "**" {
+        // Zero or more segments. GitHub treats a trailing `**` as "this
+        // directory and everything under it".
+        return (0..=seg.len()).any(|i| match seg.get(i..) {
+            Some(tail) => match_segments(pat_rest, tail),
             None => false,
-            Some(s) => match_one(p, s) && match_segments(&pat[1..], &seg[1..]),
-        },
+        });
+    }
+    match seg.split_first() {
+        None => false,
+        Some((s, seg_rest)) => match_one(head, s) && match_segments(pat_rest, seg_rest),
     }
 }
 
@@ -72,35 +79,47 @@ fn match_segments(pat: &[&str], seg: &[&str]) -> bool {
 /// non-`/` characters.
 fn match_one(pat: &str, seg: &str) -> bool {
     let parts: Vec<&str> = pat.split('*').collect();
-    if parts.len() == 1 {
+    // `split_first`/`split_last` again: the interior is what is left over,
+    // which is the same fact as "not the first and not the last" without a
+    // second expression of it that can disagree. The old
+    // `&parts[1..parts.len().saturating_sub(1)]` was that second expression.
+    let Some((first, after_first)) = parts.split_first() else {
         return pat == seg;
-    }
+    };
+    let Some((last, interior)) = after_first.split_last() else {
+        // No `*` at all: one part, so the pattern is literal.
+        return pat == seg;
+    };
+
     let mut rest = seg;
     // The first part must be a prefix (unless the pattern starts with `*`).
-    if let Some(first) = parts.first()
-        && !first.is_empty()
-    {
+    if !first.is_empty() {
         match rest.strip_prefix(*first) {
             Some(r) => rest = r,
             None => return false,
         }
     }
     // The last must be a suffix (unless the pattern ends with `*`).
-    if let Some(last) = parts.last()
-        && !last.is_empty()
-    {
+    if !last.is_empty() {
         match rest.strip_suffix(*last) {
-            Some(r) if rest.len() >= last.len() => rest = r,
-            _ => return false,
+            Some(r) => rest = r,
+            None => return false,
         }
     }
     // Interior parts must appear in order.
-    for mid in &parts[1..parts.len().saturating_sub(1)] {
+    for mid in interior {
         if mid.is_empty() {
             continue;
         }
-        match rest.find(mid) {
-            Some(i) => rest = &rest[i + mid.len()..],
+        // `find` returns a byte offset at a char boundary and `mid` is a
+        // substring from there, so the sum is a boundary too — but slicing on
+        // an arithmetic result is exactly the shape that panics when the
+        // reasoning is wrong, so take the remainder by length instead.
+        match rest.find(mid).and_then(|i| {
+            rest.get(i..)
+                .and_then(|from_match| from_match.get(mid.len()..))
+        }) {
+            Some(after) => rest = after,
             None => return false,
         }
     }
@@ -240,10 +259,15 @@ pub fn inputs_for(root: &Path, model: &Model, context: &str) -> Result<Result<In
     // fires, and the noop reports the same context green in seconds. So the
     // real twin is the gate, and its filter is the declared read-set. Dropping
     // the noop half here is the difference between 11 refusals and 11 keys.
+    // `get` rather than `[]` throughout: `producers` hands back indices into
+    // `model.workflows`, and this crate must never turn a stale index into a
+    // panic. A panic here is a key derivation that could not finish, and the
+    // whole design turns on never confusing that with a derivation that
+    // finished and said "no key".
     let real: Vec<_> = all
         .iter()
         .copied()
-        .filter(|(wi, _)| !model.workflows[*wi].is_noop())
+        .filter(|(wi, _)| model.workflows.get(*wi).is_some_and(|w| !w.is_noop()))
         .collect();
     let producers = if real.is_empty() { all.clone() } else { real };
 
@@ -259,18 +283,31 @@ pub fn inputs_for(root: &Path, model: &Model, context: &str) -> Result<Result<In
                 context: context.to_string(),
                 producers: producers
                     .iter()
-                    .map(|(wi, ji)| {
-                        format!(
-                            "{}::{}",
-                            model.workflows[*wi].path, model.workflows[*wi].jobs[*ji].id
-                        )
+                    .map(|(wi, ji)| match model.workflows.get(*wi) {
+                        Some(w) => match w.jobs.get(*ji) {
+                            Some(j) => format!("{}::{}", w.path, j.id),
+                            None => format!("{}::<job {ji} is gone>", w.path),
+                        },
+                        None => format!("<workflow {wi} is gone>::<job {ji}>"),
                     })
                     .collect(),
             }));
         }
     }
-    let (wi, _) = producers[0];
-    let w = &model.workflows[wi];
+    // The `match` above established exactly one producer, but "established by
+    // an earlier branch" is the reasoning that `[0]` panics on when someone
+    // edits the branch. Ask for it.
+    let Some(&(wi, _)) = producers.first() else {
+        return Ok(Err(Refusal::NoProducer {
+            context: context.to_string(),
+        }));
+    };
+    let Some(w) = model.workflows.get(wi) else {
+        anyhow::bail!(
+            "context {context:?} names workflow index {wi}, which the model does not have: the \
+             model changed under the index and a key derived from it would be about nothing"
+        );
+    };
 
     let Some(filter) = filter_of(w) else {
         return Ok(Err(Refusal::Unfiltered {

--- a/crates/nucleus-action-key/src/lib.rs
+++ b/crates/nucleus-action-key/src/lib.rs
@@ -252,4 +252,5 @@ impl std::fmt::Display for ActionKey {
 }
 
 pub mod census;
+pub mod closure;
 pub mod derive;

--- a/crates/nucleus-action-key/src/lib.rs
+++ b/crates/nucleus-action-key/src/lib.rs
@@ -68,6 +68,27 @@
 //! it away.
 
 #![forbid(unsafe_code)]
+// TOTALITY: a function whose signature says `-> T` and panics is lying about
+// its type. All seven lints, denied for the shipped build only — `assert!` IS
+// a panic, so denying inside `#[cfg(test)]` would forbid the thing tests are
+// made of. Measured zero of all seven before adding this, per `clippy.toml`'s
+// rule that an entry is added only when the tree is already clean of it.
+//
+// It matters more here than in most crates: this one decides whether a receipt
+// may be REUSED. A panic in the key derivation is a gate that could not look,
+// and the whole design turns on never confusing that with a gate that looked.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo
+    )
+)]
 
 use sha2::{Digest, Sha256};
 

--- a/crates/nucleus-action-key/src/main.rs
+++ b/crates/nucleus-action-key/src/main.rs
@@ -1,5 +1,27 @@
 //! `nucleus-action-key` — derive a CI gate's receipt key, or say why it has none.
 
+// TOTALITY: a function whose signature says `-> T` and panics is lying about
+// its type. All seven lints, denied for the shipped build only — `assert!` IS
+// a panic, so denying inside `#[cfg(test)]` would forbid the thing tests are
+// made of. Measured zero of all seven before adding this, per `clippy.toml`'s
+// rule that an entry is added only when the tree is already clean of it.
+//
+// It matters more here than in most crates: this one decides whether a receipt
+// may be REUSED. A panic in the key derivation is a gate that could not look,
+// and the whole design turns on never confusing that with a gate that looked.
+#![cfg_attr(
+    not(test),
+    deny(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::indexing_slicing,
+        clippy::arithmetic_side_effects,
+        clippy::panic,
+        clippy::unreachable,
+        clippy::todo
+    )
+)]
+
 use anyhow::Result;
 use nucleus_action_key::census::{self, Outcome};
 use std::path::PathBuf;

--- a/crates/nucleus-action-key/src/main.rs
+++ b/crates/nucleus-action-key/src/main.rs
@@ -24,12 +24,23 @@
 
 use anyhow::Result;
 use nucleus_action_key::census::{self, Outcome};
-use std::path::PathBuf;
+use nucleus_action_key::{closure, derive};
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
 
 fn main() -> Result<()> {
     let root = std::env::var("NUCLEUS_REPO_ROOT")
         .map(PathBuf::from)
         .unwrap_or_else(|_| PathBuf::from("."));
+
+    // `--crates` reports the DERIVED read-sets: one per workspace crate, from
+    // `cargo metadata`'s dependency graph rather than a hand-written `paths:`
+    // filter. Every crate has one, which is the point — the 37 contexts the
+    // context census refuses for want of a declaration need no declaration
+    // here.
+    if std::env::args().nth(1).as_deref() == Some("--crates") {
+        return crates_report(&root);
+    }
 
     let census = census::run(&root)?;
 
@@ -88,6 +99,31 @@ fn main() -> Result<()> {
     // vacuity these gates exist to find.
     if census.unmeasured() > 0 {
         std::process::exit(2);
+    }
+    Ok(())
+}
+
+/// One line per crate: how many crates its closure spans and how many files
+/// that is, widest first.
+fn crates_report(root: &Path) -> Result<()> {
+    let ws = closure::load(root)?;
+    let tracked = derive::tracked_files(root)?;
+    let mut rows: Vec<(usize, usize, &String)> = Vec::new();
+    for name in ws.closures.keys() {
+        let files = ws.read_set(root, &tracked, name)?.len();
+        let span = ws.closures.get(name).map_or(0, BTreeSet::len);
+        rows.push((span, files, name));
+    }
+    rows.sort_unstable();
+    rows.reverse();
+    println!(
+        "{} crate(s), {} tracked file(s) in the tree",
+        rows.len(),
+        tracked.len()
+    );
+    println!("{:>6}  {:>6}  crate", "closure", "files");
+    for (span, files, name) in &rows {
+        println!("{span:>6}  {files:>6}  {name}");
     }
     Ok(())
 }

--- a/crates/nucleus-action-key/tests/closure_keys.rs
+++ b/crates/nucleus-action-key/tests/closure_keys.rs
@@ -1,0 +1,260 @@
+//! The property that makes a closure key sound, and the one that makes it worth
+//! having.
+//!
+//! **Sound:** a change anywhere in a crate's closure moves its key. If it did
+//! not, a receipt would be reused for a crate whose dependency changed
+//! underneath it — a green check for work nobody did on the code in question,
+//! which is the one failure that makes a receipt store worse than no cache.
+//!
+//! **Worth having:** a change OUTSIDE the closure does not move it. Without
+//! that, every merge-group entry is a cold cache and the whole design buys
+//! nothing — which is the state gatehouse's `docs/hard-cut.md` §6 records for
+//! its own receipts today.
+//!
+//! Both run against a real cargo workspace in a tempdir. A fixture that stubbed
+//! `cargo metadata` would be testing a different function: the graph is exactly
+//! the thing being trusted here.
+
+use nucleus_action_key::{closure, derive};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn run(dir: &Path, prog: &str, args: &[&str]) {
+    let out = Command::new(prog)
+        .args(args)
+        .current_dir(dir)
+        .env("GIT_AUTHOR_NAME", "t")
+        .env("GIT_AUTHOR_EMAIL", "t@t")
+        .env("GIT_COMMITTER_NAME", "t")
+        .env("GIT_COMMITTER_EMAIL", "t@t")
+        .output()
+        .expect("spawns");
+    assert!(
+        out.status.success(),
+        "{prog} {args:?}: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn write(root: &Path, rel: &str, body: &str) {
+    let p = root.join(rel);
+    std::fs::create_dir_all(p.parent().expect("has a parent")).expect("mkdir");
+    std::fs::write(p, body).expect("write");
+}
+
+/// Three crates: `leaf`, `mid` (depends on leaf), `far` (depends on neither).
+/// The shape that distinguishes "in the closure" from "in the workspace".
+fn fixture() -> PathBuf {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    static N: AtomicU32 = AtomicU32::new(0);
+    let root = std::env::temp_dir().join(format!(
+        "nucleus-closure-{}-{}",
+        std::process::id(),
+        N.fetch_add(1, Ordering::Relaxed)
+    ));
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).expect("mkdir");
+
+    write(
+        &root,
+        "Cargo.toml",
+        "[workspace]\nresolver = \"2\"\nmembers = [\"crates/leaf\", \"crates/mid\", \"crates/far\"]\n",
+    );
+    for (name, dep) in [("leaf", None), ("mid", Some("leaf")), ("far", None)] {
+        let d = dep.map_or(String::new(), |d| {
+            format!("\n[dependencies]\n{d} = {{ path = \"../{d}\" }}\n")
+        });
+        write(
+            &root,
+            &format!("crates/{name}/Cargo.toml"),
+            &format!("[package]\nname = \"{name}\"\nversion = \"0.1.0\"\nedition = \"2021\"\n{d}"),
+        );
+        write(
+            &root,
+            &format!("crates/{name}/src/lib.rs"),
+            "pub fn f() {}\n",
+        );
+    }
+    write(
+        &root,
+        "rust-toolchain.toml",
+        "[toolchain]\nchannel = \"stable\"\n",
+    );
+    write(&root, "docs/unrelated.md", "not a crate\n");
+
+    run(&root, "git", &["init", "-q", "-b", "main"]);
+    run(&root, "cargo", &["generate-lockfile", "--offline"]);
+    run(&root, "git", &["add", "-A"]);
+    root
+}
+
+fn key(root: &Path, name: &str) -> String {
+    let ws = closure::load(root).expect("metadata");
+    let tracked = derive::tracked_files(root).expect("git ls-files");
+    closure::key_for_crate(&ws, root, &tracked, name, "clippy", &[])
+        .expect("key")
+        .to_hex()
+}
+
+#[test]
+fn the_closure_is_the_crate_and_what_it_depends_on() {
+    let root = fixture();
+    let ws = closure::load(&root).expect("metadata");
+    let c = |n: &str| {
+        let mut v: Vec<String> = ws.closures.get(n).expect("crate").iter().cloned().collect();
+        v.sort();
+        v
+    };
+    assert_eq!(c("leaf"), vec!["leaf"]);
+    assert_eq!(c("mid"), vec!["leaf", "mid"]);
+    assert_eq!(c("far"), vec!["far"]);
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// **Sound.** A dependency changing must move the dependent's key, or a receipt
+/// outlives the code it was about.
+#[test]
+fn a_change_to_a_dependency_moves_the_dependents_key() {
+    let root = fixture();
+    let before = key(&root, "mid");
+    write(
+        &root,
+        "crates/leaf/src/lib.rs",
+        "pub fn f() { let _ = 1; }\n",
+    );
+    run(&root, "git", &["add", "-A"]);
+    assert_ne!(
+        before,
+        key(&root, "mid"),
+        "leaf changed and mid's key did not move: mid would reuse a receipt taken before its \
+         dependency changed"
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// **Worth having.** A crate outside the closure must NOT move it — this is the
+/// entire payoff, and without it every merge-group entry is a cold cache.
+#[test]
+fn a_change_to_an_unrelated_crate_does_not_move_the_key() {
+    let root = fixture();
+    let before = key(&root, "mid");
+    write(
+        &root,
+        "crates/far/src/lib.rs",
+        "pub fn f() { let _ = 2; }\n",
+    );
+    run(&root, "git", &["add", "-A"]);
+    assert_eq!(
+        before,
+        key(&root, "mid"),
+        "an unrelated crate moved mid's key"
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// A non-crate file — a workflow, a doc, a script — must not move any key.
+/// This is the 33%: a third of merges to main touch nothing else.
+#[test]
+fn a_change_outside_every_crate_moves_no_key() {
+    let root = fixture();
+    let before: Vec<String> = ["leaf", "mid", "far"]
+        .iter()
+        .map(|n| key(&root, n))
+        .collect();
+    write(
+        &root,
+        "docs/unrelated.md",
+        "still not a crate, but different\n",
+    );
+    write(&root, ".github/workflows/ci.yml", "name: CI\n");
+    run(&root, "git", &["add", "-A"]);
+    let after: Vec<String> = ["leaf", "mid", "far"]
+        .iter()
+        .map(|n| key(&root, n))
+        .collect();
+    assert_eq!(before, after, "a CI-only change invalidated a crate key");
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// The direction that must NOT hold: a dependent changing must not move its
+/// dependency's key. `leaf` does not read `mid`, so `leaf`'s receipt stands.
+#[test]
+fn a_change_to_a_dependent_does_not_move_the_dependencys_key() {
+    let root = fixture();
+    let before = key(&root, "leaf");
+    write(
+        &root,
+        "crates/mid/src/lib.rs",
+        "pub fn f() { let _ = 3; }\n",
+    );
+    run(&root, "git", &["add", "-A"]);
+    assert_eq!(
+        before,
+        key(&root, "leaf"),
+        "a dependent moved its dependency's key"
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// `Cargo.lock` and the toolchain are in EVERY closure: an external dependency
+/// or a compiler moving changes what every crate compiles to. That is the 13%
+/// of merges which legitimately invalidate everything.
+///
+/// Asserted as membership rather than by perturbing the lockfile, because
+/// `cargo metadata` REWRITES `Cargo.lock` — a test that appended a comment
+/// measured cargo normalising it away, not the key. The claim is that the file
+/// is committed to; making cargo fight the fixture tests something else.
+#[test]
+fn every_closure_contains_the_lockfile_and_the_toolchain() {
+    let root = fixture();
+    let ws = closure::load(&root).expect("metadata");
+    let tracked = derive::tracked_files(&root).expect("git ls-files");
+    for name in ["leaf", "mid", "far"] {
+        let paths: Vec<String> = ws
+            .read_set(&root, &tracked, name)
+            .expect("read set")
+            .into_iter()
+            .map(|e| e.path)
+            .collect();
+        assert!(
+            paths.contains(&"Cargo.lock".to_string()),
+            "{name} omits Cargo.lock"
+        );
+        assert!(
+            paths.contains(&"rust-toolchain.toml".to_string()),
+            "{name} omits the toolchain"
+        );
+    }
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+/// The read-set must actually contain the closure's sources. The first version
+/// of `from_metadata` produced read-sets of exactly two files for every crate —
+/// a `strip_prefix` that failed on macOS's `/var` symlink and left the
+/// directories absolute — and four of six tests still passed, because "nothing
+/// changed" is the easy half of every property here.
+#[test]
+fn the_read_set_contains_the_closures_sources() {
+    let root = fixture();
+    let ws = closure::load(&root).expect("metadata");
+    let tracked = derive::tracked_files(&root).expect("git ls-files");
+    let paths: Vec<String> = ws
+        .read_set(&root, &tracked, "mid")
+        .expect("read set")
+        .into_iter()
+        .map(|e| e.path)
+        .collect();
+    assert!(
+        paths.contains(&"crates/mid/src/lib.rs".to_string()),
+        "{paths:?}"
+    );
+    assert!(
+        paths.contains(&"crates/leaf/src/lib.rs".to_string()),
+        "{paths:?}"
+    );
+    assert!(
+        !paths.contains(&"crates/far/src/lib.rs".to_string()),
+        "{paths:?}"
+    );
+    let _ = std::fs::remove_dir_all(&root);
+}


### PR DESCRIPTION
The context census said 11 of 48 required contexts can be keyed, and named the other 37 as needing someone to **declare** what they read. That conclusion was wrong, and this is why.

A Rust crate's read-set is not a matter of opinion. It is the crate's own sources plus the sources of every workspace crate it depends on, and `cargo metadata` knows the graph exactly. **Nothing has to be declared, so nothing can be declared wrongly** — which is the single weakness the `paths:` key carries, and the one gatehouse's scope-as-oid exists to remove.

## What it is worth, measured

Over nucleus's last 39 first-parent merges to `main`, against 82 crates:

| | |
|---|---|
| merges affecting **zero** crates | **13 of 39 (33%)** |
| median crates affected | **1 of 82** |
| merges invalidating everything (lock/toolchain) | 5 of 39 (13%) |

A third of merges to main are CI-only — workflows, scripts, docs — and every one rebuilds and re-tests all 82 crates in the merge queue, because `ci.yml`'s `changed-crates` sets `all=true` under `merge_group`. That is *not a bug*: a merge group is a new combination, and narrowing it on a PR's diff would be unsound. A receipt keyed on a closure is what can narrow it soundly.

This independently reproduces gatehouse's own figure — `docs/scope-fanout.md` measured 37% of merged changes running zero gates under per-crate scopes, by a different method.

Over this workspace: 82 crates, 1,968 tracked files, closures from **1 crate / 4 files** (`nucleus-provenance`) to **24 crates / 682 files** (`nucleus-node`). `nucleus-action-key --crates` reports it.

## The bug the tests found, which is the interesting part

`strip_prefix(root)` against cargo's `manifest_path` fails on macOS: `/var` is a symlink to `/private/var` and cargo reports the resolved path. It does not error — `unwrap_or(dir)` left every directory **absolute**, the prefix match against repo-relative filenames found nothing, and **every crate's read-set silently collapsed to two workspace-wide files**.

Four of six tests still passed, because *"nothing changed" is the easy half of every property here* — a read-set of almost nothing is extremely stable. Only the two soundness tests caught it. It is now a refusal rather than a fallback, and a new test asserts the positive direction directly.

## Seven properties

**Sound:** a dependency's change moves the dependent's key; the lockfile and toolchain are in every closure.
**Worth having:** an unrelated crate does not move it; a dependent does not move its dependency's; a change outside every crate moves nothing — that last one is the 33%.

The lockfile property is asserted as *membership*, not by perturbing the file: `cargo metadata` rewrites `Cargo.lock`, so a test that appended a comment was measuring cargo normalising it away rather than measuring the key.

Stacked on #2858 (the totality declaration), since this adds code to the same crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016t7JSuCtg4dC54HZjFgBjr