### PR TITLE
fix(ci): register the inline gate I added, and raise the ceiling for it

### DIFF
--- a/ci/inline-gates.txt
+++ b/ci/inline-gates.txt
@@ -11,7 +11,7 @@
 # Regenerate with `cargo xtask ci-spec inline-gates > ci/inline-gates.txt`
 # (annotations are carried forward).
 #
-# UNCOVERED_CEILING = 90
+# UNCOVERED_CEILING = 91
 #
 # 2026-09-11: 80 → 90. The grep-only consolidation folds eleven single-script
 # gate jobs into `ci.yml`'s `text-gates` and relays each outcome back to its own
@@ -24,6 +24,21 @@
 # (action-smoke-test.yml::dry-run and two podlist-probe steps) are PRE-EXISTING
 # drift and are deliberately left out: a ratchet that quietly swallows
 # unrelated debt is not a ratchet.
+#
+# 2026-09-12: 90 → 91, and the entry is mine. #2851 added an operand guard to
+# `Ratchet down` — the four values it computes a new ceiling from must be
+# integers, because `$(( ))` treats an empty operand as 0 SILENTLY and the job
+# would then rewrite .clippy-ratchet.toml to whatever the tree measures, which
+# does not fail the ratchet, it deletes it. That guard is an `exit 1` in a `run:`
+# block, so it is an inline gate, and I did not register it. `ci-spec` said so
+# (CI-I8-UNLISTED) at a severity that does not fail, which is exactly the reading
+# gatehouse F-89 records: a finding that appears and is scrolled past.
+#
+# UNCOVERED rather than a falsifier, honestly: the step is `if:`-gated to `push`
+# on main, so check-gates-can-fail.sh cannot invoke it and no probe reaches it.
+# The guard's behaviour WAS verified by hand on the script half — an empty and a
+# non-numeric ceiling each exit 2 naming the value — but the workflow half has no
+# runnable falsifier, and saying "no falsifier yet" is the true statement.
 
 a2a-tck.yml::tck::Start the target on :9999 | UNCOVERED: no falsifier yet
 action-smoke-test.yml::dry-run::Dry-run: safe_pr_fixer profile | UNCOVERED: no falsifier yet
@@ -79,6 +94,7 @@ ci.yml::declassify-governor-keys-sealed::Report | UNCOVERED: no falsifier yet
 ck-policy-aeneas.yml::ck-policy-aeneas::Verify generated Lean matches committed (drift gate) | UNCOVERED: no falsifier yet
 ck-policy-aeneas.yml::ck-policy-aeneas::Ban sorry / admit / native_decide in our proof file | UNCOVERED: no falsifier yet
 ck-policy-lean.yml::ck-policy-lean::Ban sorry / admit / native_decide / sorryAx in ck-policy Lean | UNCOVERED: no falsifier yet
+clippy-ratchet.yml::ratchet-down::Ratchet down | UNCOVERED: `if:`-gated to push on main, so no probe can invoke it
 clippy-ratchet.yml::ratchet-falsifier::RED on a ceiling below actual, GREEN when restored | UNCOVERED: no falsifier yet
 coverage-matrix.yml::mutants::The gate reads the machine report, not the console (#2562) | UNCOVERED: no falsifier yet
 crates-publish.yml::publish::Publish in dependency order (idempotent) | UNCOVERED: no falsifier yet


### PR DESCRIPTION
#2851 added an operand guard to `clippy-ratchet.yml`'s `Ratchet down` step. That guard is an `exit 1` inside a `run:` block — the definition of an inline gate in `ci/inline-gates.txt` — and **I did not register it**.

`ci-spec` noticed immediately and said so as `CI-I8-UNLISTED`. At a severity that does not fail, so it sat in the advisory list beside three older ones and nothing stopped me. That is gatehouse **F-89**'s shape landing on my own change: a real finding, correctly reported, filed where it gets scrolled past.

## Why the guard exists

The `Ratchet down` job computes `NEW=$((CEILING - STEP))`. `$(( ))` does not error on a bad operand the way `[ -gt ]` does — it treats an empty value as **0 silently**, the clamps then snap `NEW` to the measured count, and the job opens a PR rewriting `.clippy-ratchet.toml` to whatever the tree happens to be. **That does not fail the ratchet, it deletes it.**

## `UNCOVERED`, stated honestly

The step is `if:`-gated to `push` on main, so `check-gates-can-fail.sh` cannot invoke it and no probe reaches it. The guard's behaviour *was* verified by hand on the script half — an empty and a non-numeric ceiling each exit 2 naming the value — but the workflow half has no runnable falsifier, and *"no falsifier yet"* is the true statement rather than a placeholder.

`UNCOVERED_CEILING` **90 → 91**, reason dated in place. Raising an only-shrinks ceiling is a deliberate act, and this one is mine to own.

## Verification, both directions

| perturbation | result |
|---|---|
| ceiling left at 90 | **`CRITICAL [CI-I8-CEILING]` — "91 UNCOVERED inline gates, ceiling 90: the ratchet only shrinks"**, exit 1 |
| entry removed | the unlisted finding returns |

The first matters: it shows the raise is **load-bearing rather than cosmetic** — the ceiling is hard-gated even though membership is advisory, which is exactly the asymmetry that let an unregistered gate through.

`CI-I8-UNLISTED` drops **4 → 3**, the remaining three predating this change. `check-ci-spec.sh` RC=0; the file restores byte-exact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)