### PR TITLE
Read the exit report out of a microVM, so a pod receipt is reachable

### DIFF
--- a/crates/nucleus-node/src/pod_receipt.rs
+++ b/crates/nucleus-node/src/pod_receipt.rs
@@ -23,6 +23,12 @@
 //! is what a GET should be. The asymmetry is the bug being contained rather than spread, and it is
 //! written down here so the next person finds a decision instead of an inconsistency.
 
+// Declared HERE, not in main.rs, because this is the only thing that needs it:
+// the read-back exists so a receipt can be built for a microVM. It also keeps
+// `main.rs` off its line ceiling, which it was sitting exactly on.
+#[path = "scratch_readback.rs"]
+mod scratch_readback;
+
 use std::sync::Arc;
 
 use serde::Serialize;
@@ -97,9 +103,39 @@ pub(crate) async fn build(handle: &Arc<PodHandle>) -> Result<Built, ReceiptError
     };
 
     let report_path = handle.spec.spec.work_dir.join(".nucleus-exit-report.json");
-    let report_json = tokio::fs::read_to_string(&report_path)
-        .await
-        .map_err(|e| ReceiptError::NoExitReport(format!("{}: {e}", report_path.display())))?;
+    let report_json = match tokio::fs::read_to_string(&report_path).await {
+        Ok(json) => json,
+        // A MICROVM SHARES NO DIRECTORY, so this path never existed for it.
+        //
+        // `nucleus-spec` says so outright — "A microVM has no host-directory
+        // mount and there never will be one" — which means this function has
+        // returned `NoExitReport` for every Firecracker pod since it was
+        // written. The guest's `/work` is a block device; its report is inside
+        // that image, and the host owns the image.
+        //
+        // ORDERING HAZARD, stated because it is real: the jail is removed at
+        // teardown (`FirecrackerPod::jail` is held "so teardown can remove
+        // it"). This read must happen while the jail still exists. A jail
+        // already gone reads as `Absent`, which is honest but is NOT the same
+        // as the pod having written nothing — so a receipt built too late is
+        // indistinguishable from a workload that crashed early, and that is a
+        // gap this comment is recording rather than closing.
+        Err(host_err) => match scratch_report(handle).await {
+            Some(Ok(json)) => json,
+            Some(Err(readback)) => {
+                return Err(ReceiptError::NoExitReport(format!(
+                    "{}: {host_err}; and the scratch disk: {readback}",
+                    report_path.display()
+                )));
+            }
+            None => {
+                return Err(ReceiptError::NoExitReport(format!(
+                    "{}: {host_err}",
+                    report_path.display()
+                )));
+            }
+        },
+    };
     let report: nucleus_spec::ExitReport =
         serde_json::from_str(&report_json).map_err(|e| ReceiptError::Malformed(e.to_string()))?;
 
@@ -527,4 +563,30 @@ mod tests {
             assert!(built.trust_bracket.is_none());
         }
     }
+}
+
+/// The exit report read out of a Firecracker pod's scratch image, or `None`
+/// when this pod has no such image (every other driver shares a directory and
+/// never reaches here).
+///
+/// The guest mounts the image at `/work`, so `/work/.nucleus-exit-report.json`
+/// in the guest is `/.nucleus-exit-report.json` in the filesystem.
+async fn scratch_report(
+    handle: &Arc<PodHandle>,
+) -> Option<Result<String, scratch_readback::ReadbackError>> {
+    let crate::DriverState::Firecracker(pod) = &handle.driver_state else {
+        return None;
+    };
+    let jail = pod.jail.lock().await;
+    let layout = jail.as_ref()?;
+    let image = layout
+        .jail_root
+        .join(crate::firecracker_config::in_jail::SCRATCH.trim_start_matches('/'));
+    if !image.exists() {
+        return None;
+    }
+    Some(
+        scratch_readback::read_file(&image, "/.nucleus-exit-report.json")
+            .map(|b| String::from_utf8_lossy(&b).into_owned()),
+    )
 }

--- a/crates/nucleus-node/src/pod_receipt.rs
+++ b/crates/nucleus-node/src/pod_receipt.rs
@@ -245,6 +245,32 @@ pub(crate) fn report_to_trust_gate(state: &NodeState, built: &Built) {
     });
 }
 
+/// The exit report read out of a Firecracker pod's scratch image, or `None`
+/// when this pod has no such image (every other driver shares a directory and
+/// never reaches here).
+///
+/// The guest mounts the image at `/work`, so `/work/.nucleus-exit-report.json`
+/// in the guest is `/.nucleus-exit-report.json` in the filesystem.
+async fn scratch_report(
+    handle: &Arc<PodHandle>,
+) -> Option<Result<String, scratch_readback::ReadbackError>> {
+    let crate::DriverState::Firecracker(pod) = &handle.driver_state else {
+        return None;
+    };
+    let jail = pod.jail.lock().await;
+    let layout = jail.as_ref()?;
+    let image = layout
+        .jail_root
+        .join(crate::firecracker_config::in_jail::SCRATCH.trim_start_matches('/'));
+    if !image.exists() {
+        return None;
+    }
+    Some(
+        scratch_readback::read_file(&image, "/.nucleus-exit-report.json")
+            .map(|b| String::from_utf8_lossy(&b).into_owned()),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -563,30 +589,4 @@ mod tests {
             assert!(built.trust_bracket.is_none());
         }
     }
-}
-
-/// The exit report read out of a Firecracker pod's scratch image, or `None`
-/// when this pod has no such image (every other driver shares a directory and
-/// never reaches here).
-///
-/// The guest mounts the image at `/work`, so `/work/.nucleus-exit-report.json`
-/// in the guest is `/.nucleus-exit-report.json` in the filesystem.
-async fn scratch_report(
-    handle: &Arc<PodHandle>,
-) -> Option<Result<String, scratch_readback::ReadbackError>> {
-    let crate::DriverState::Firecracker(pod) = &handle.driver_state else {
-        return None;
-    };
-    let jail = pod.jail.lock().await;
-    let layout = jail.as_ref()?;
-    let image = layout
-        .jail_root
-        .join(crate::firecracker_config::in_jail::SCRATCH.trim_start_matches('/'));
-    if !image.exists() {
-        return None;
-    }
-    Some(
-        scratch_readback::read_file(&image, "/.nucleus-exit-report.json")
-            .map(|b| String::from_utf8_lossy(&b).into_owned()),
-    )
 }

--- a/crates/nucleus-node/src/scratch_readback.rs
+++ b/crates/nucleus-node/src/scratch_readback.rs
@@ -1,0 +1,232 @@
+//! Reading a file the GUEST wrote out of a microVM, from the host.
+//!
+//! # The gap this closes
+//!
+//! `pod_receipt::build` reads `<work_dir>/.nucleus-exit-report.json`. That is a
+//! **host** path, and it works for the local and container drivers because they
+//! share a directory with the workload. A Firecracker guest shares nothing:
+//! `nucleus-spec` states it outright — *"A microVM has no host-directory mount
+//! and there never will be one."* The guest's `/work` is a block device, an
+//! ext4 image the host owns inside the jail.
+//!
+//! So `pod_receipt::build` returns `NoExitReport` for **every Firecracker pod**,
+//! always has, and the receipt path has never been reachable from the driver
+//! that matters. This is the read-back that makes it reachable.
+//!
+//! # Why `debugfs` and not a loopback mount
+//!
+//! Mounting needs `CAP_SYS_ADMIN` and a loop device, which is privilege the node
+//! does not otherwise need and would have to hold for the lifetime of the read.
+//! `debugfs -R "dump …"` reads the filesystem from userspace, unprivileged, with
+//! the image still a plain file.
+//!
+//! It costs no new dependency: `provision_pod_scratch` already requires
+//! e2ffsprogs to *create* the image (`mkfs.ext4`), and `debugfs` ships in the
+//! same package. A host that can make a scratch disk can read one.
+//!
+//! # Why the host reads rather than the guest shipping
+//!
+//! There is a `SHIP_RECEIPT` command and this could have been `SHIP_EXIT_REPORT`
+//! beside it. It is deliberately not.
+//!
+//! The exit report is an input to a receipt the HOST signs. Every field the
+//! guest hands over is a field the receipt has to qualify as "the guest said
+//! so", and the guest is the one thing in the system whose word the receipt is
+//! supposed to not depend on. Reading the bytes out of an image the host owns
+//! keeps the guest's contribution to what it actually is — content the host
+//! measures — rather than a claim the host relays.
+//!
+//! # What this does NOT establish
+//!
+//! That the report is true. The guest wrote it, and a compromised workload
+//! writes whatever it likes. What changes is only WHO IS QUOTED: the host says
+//! "this is what was in the image", not "the guest told me this over a socket".
+//! The signature over it is the host's either way, and neither form makes the
+//! content trustworthy. See `pod_authority.rs` for the key, and
+//! `attestation.rs:10-18` for the conditional the whole chain rests on.
+
+use std::path::Path;
+
+/// Why a read-back did not produce bytes.
+#[derive(Debug)]
+pub(crate) enum ReadbackError {
+    /// `debugfs` is not installed. Named rather than folded into "no report":
+    /// a host that cannot look is not a pod that produced nothing, and
+    /// reporting the first as the second is the vacuity ADR 0002 was written
+    /// about.
+    ToolMissing(String),
+    /// `debugfs` ran and failed.
+    Failed(String),
+    /// The path is not in the image. This one IS "the guest produced nothing",
+    /// which is a legitimate outcome for a workload that crashed early.
+    Absent(String),
+}
+
+impl std::fmt::Display for ReadbackError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ReadbackError::ToolMissing(e) => write!(
+                f,
+                "debugfs is not available on this host, so the scratch disk could not be read: \
+                 {e} — install e2fsprogs (the same package mkfs.ext4 comes from). This is 'could \
+                 not look', not 'the pod wrote nothing'"
+            ),
+            ReadbackError::Failed(e) => write!(f, "debugfs failed reading the scratch disk: {e}"),
+            ReadbackError::Absent(p) => write!(f, "{p} is not in the scratch disk"),
+        }
+    }
+}
+
+/// `debugfs`'s own words when a path is not in the image.
+const NOT_FOUND: &[&str] = &["File not found", "not found by ext2_lookup"];
+
+/// Read `guest_path` out of the ext4 at `image`, as bytes.
+///
+/// `guest_path` is the path INSIDE the filesystem — the guest mounts the image
+/// at `/work`, so `/work/.nucleus-exit-report.json` in the guest is
+/// `/.nucleus-exit-report.json` here.
+pub(crate) fn read_file(image: &Path, guest_path: &str) -> Result<Vec<u8>, ReadbackError> {
+    let out_dir =
+        tempfile_dir().map_err(|e| ReadbackError::Failed(format!("staging directory: {e}")))?;
+    let staged = out_dir.join("readback");
+
+    let out = std::process::Command::new("debugfs")
+        .args([
+            "-R",
+            &format!("dump {guest_path} {}", staged.display()),
+            &image.display().to_string(),
+        ])
+        .output()
+        .map_err(|e| ReadbackError::ToolMissing(e.to_string()))?;
+
+    // `debugfs -R` exits 0 even when the dump failed — it reports on stderr and
+    // leaves no file. Exit status is NOT the signal here, the same trap the
+    // dylint gates document for `cargo dylint`.
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    if NOT_FOUND.iter().any(|m| stderr.contains(m)) {
+        let _ = std::fs::remove_dir_all(&out_dir);
+        return Err(ReadbackError::Absent(guest_path.to_string()));
+    }
+
+    let bytes = std::fs::read(&staged).map_err(|e| {
+        if stderr.trim().is_empty() {
+            ReadbackError::Absent(format!("{guest_path} ({e})"))
+        } else {
+            ReadbackError::Failed(format!("{}: {e}", stderr.trim()))
+        }
+    });
+    let _ = std::fs::remove_dir_all(&out_dir);
+    bytes
+}
+
+/// A private staging directory, named by pid and a counter.
+///
+/// Not the clock: nine tests sharing a wall-clock-nanos name was #2825, and the
+/// same mistake here would have two pods' read-backs land on one path.
+fn tempfile_dir() -> std::io::Result<std::path::PathBuf> {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static N: AtomicU64 = AtomicU64::new(0);
+    let dir = std::env::temp_dir().join(format!(
+        "nucleus-readback-{}-{}",
+        std::process::id(),
+        N.fetch_add(1, Ordering::Relaxed)
+    ));
+    std::fs::create_dir_all(&dir)?;
+    Ok(dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn have_e2fsprogs() -> bool {
+        std::process::Command::new("debugfs")
+            .arg("-V")
+            .output()
+            .is_ok()
+            && std::process::Command::new("mkfs.ext4")
+                .arg("-V")
+                .output()
+                .is_ok()
+    }
+
+    /// Round trip: make an image, put a file in it the way a guest would, read
+    /// it back from the host without mounting anything.
+    ///
+    /// Skips where e2fsprogs is absent (macOS), which is the same shape the
+    /// snapshot tests use — and is why this is ALSO exercised on the Linux CI
+    /// lane rather than only here.
+    #[test]
+    fn a_file_the_guest_wrote_is_readable_from_the_host() {
+        if !have_e2fsprogs() {
+            eprintln!("skipping: e2fsprogs not installed");
+            return;
+        }
+        let dir = tempfile_dir().expect("staging");
+        let image = dir.join("scratch.ext4");
+        std::fs::write(&image, vec![0u8; 2 * 1024 * 1024]).expect("sparse image");
+        assert!(
+            std::process::Command::new("mkfs.ext4")
+                .args(["-q", "-F", &image.display().to_string()])
+                .output()
+                .expect("mkfs")
+                .status
+                .success()
+        );
+
+        // `debugfs -w -R "write <src> <dst>"` is how a file gets in without a
+        // mount — the host-side stand-in for the guest writing to /work.
+        let src = dir.join("report.json");
+        std::fs::write(&src, br#"{"workspace_hash":"abc"}"#).expect("src");
+        let put = std::process::Command::new("debugfs")
+            .args([
+                "-w",
+                "-R",
+                &format!("write {} .nucleus-exit-report.json", src.display()),
+                &image.display().to_string(),
+            ])
+            .output()
+            .expect("debugfs write");
+        assert!(
+            put.status.success(),
+            "{}",
+            String::from_utf8_lossy(&put.stderr)
+        );
+
+        let got = read_file(&image, "/.nucleus-exit-report.json").expect("read back");
+        assert_eq!(got, br#"{"workspace_hash":"abc"}"#);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// **A missing file is `Absent`, never `Failed`.** A workload that crashed
+    /// before writing a report produced nothing, and that is a different fact
+    /// from a host that could not look.
+    #[test]
+    fn a_path_not_in_the_image_is_absent_not_a_failure() {
+        if !have_e2fsprogs() {
+            eprintln!("skipping: e2fsprogs not installed");
+            return;
+        }
+        let dir = tempfile_dir().expect("staging");
+        let image = dir.join("scratch.ext4");
+        std::fs::write(&image, vec![0u8; 2 * 1024 * 1024]).expect("image");
+        let _ = std::process::Command::new("mkfs.ext4")
+            .args(["-q", "-F", &image.display().to_string()])
+            .output();
+
+        let err = read_file(&image, "/nothing-here.json").expect_err("must not succeed");
+        assert!(matches!(err, ReadbackError::Absent(_)), "{err:?}");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The three outcomes stay distinct in their own words: a host that cannot
+    /// look must not read as a pod that wrote nothing.
+    #[test]
+    fn could_not_look_and_wrote_nothing_say_different_things() {
+        let missing = ReadbackError::ToolMissing("No such file or directory".into()).to_string();
+        let absent = ReadbackError::Absent("/x.json".into()).to_string();
+        assert!(missing.contains("could not look"), "{missing}");
+        assert!(!absent.contains("could not look"), "{absent}");
+        assert!(missing.contains("e2fsprogs"), "{missing}");
+    }
+}


### PR DESCRIPTION
M2 step 2. `pod_receipt::build` reads `<work_dir>/.nucleus-exit-report.json` — a **host** path. That works for the local and container drivers, which share a directory with the workload. A Firecracker guest shares nothing; `nucleus-spec` says so outright:

> *"A microVM has no host-directory mount and there never will be one."*

So this function has returned `NoExitReport` for **every Firecracker pod since it was written**. The receipt path has never been reachable from the driver that matters, and nothing said so.

## How

`debugfs -R "dump …"` reads the ext4 scratch image from userspace, with the image still a plain file. No loopback mount — so no `CAP_SYS_ADMIN` the node doesn't otherwise need, held for the length of a read.

**No new dependency**: `provision_pod_scratch` already requires e2fsprogs to *create* the image, and its own warning says so ("Install e2fsprogs (mkfs.ext4)"). `debugfs` ships in that package. A host that can make a scratch disk can read one.

## Why the host reads rather than the guest shipping

There is a `SHIP_RECEIPT` command and this could have been `SHIP_EXIT_REPORT` beside it. Deliberately not.

The exit report is an input to a receipt the **host** signs, and every field the guest hands over is a field the receipt has to qualify as *"the guest said so"*. Reading bytes out of an image the host owns keeps the guest's contribution to what it actually is — content the host measures — rather than a claim the host relays.

This does **not** make the report true. A compromised workload writes what it likes. What changes is *who is quoted*.

## Three outcomes, kept distinct

| | |
|---|---|
| `ToolMissing` | debugfs absent — "could not look", and it says so |
| `Failed` | debugfs ran and failed |
| `Absent` | the path is not in the image — the pod wrote nothing |

`debugfs -R` **exits 0 even when the dump failed**, reporting on stderr and leaving no file — so exit status is not the signal, the same trap the dylint gates document for `cargo dylint`. A test pins that the three say different things.

## Verified where it matters

The round-trip test skips on macOS (no e2fsprogs) and was run in the Linux VM with real e2fsprogs — make an ext4, write a file in the way a guest would, read it back host-side. **3 passed.**

## Two hazards recorded rather than hidden

The jail is removed at teardown, so this read must happen while it still exists. A jail already gone reads as `Absent` — honest, but not the same fact as a workload that crashed early. The comment records that gap; it does not close it.

And `mod scratch_readback;` is declared in `pod_receipt.rs`, not `main.rs`, because main.rs sits **exactly** on its 4007-line ceiling. My first attempt to make room merged two `nucleus_spec` imports — one of which was behind `#[cfg(target_os = "linux")]`, so the merge hid `PodSpec` on macOS. Third time a Linux `cfg` has bitten this session; the local build caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016t7JSuCtg4dC54HZjFgBjr