### PR TITLE
The node signs a pod receipt, with a key no guest ever holds

### DIFF
--- a/crates/nucleus-node/proto/nucleus_node.proto
+++ b/crates/nucleus-node/proto/nucleus_node.proto
@@ -124,6 +124,20 @@ message ExecutionReceipt {
   uint64 cache_read_tokens = 14;
   // Estimated cost in USD (IEEE 754 double)
   double cost_usd = 15;
+
+  // === v1.2 The node's signature ===
+  //
+  // Hex Ed25519 over the receipt's tagged, length-prefixed preimage (every
+  // field above; not these two, since a signature cannot cover itself). The
+  // NODE signs — the key is the one in pod_authority and never enters a guest,
+  // which is what makes the signature worth more than the pod's own word.
+  //
+  // Empty when the node could not sign. A receipt that looks signed and is not
+  // would be worse than an unsigned one.
+  string signature = 16;
+  // The root public key that made it, hex, so a relying party can verify
+  // without asking the signer.
+  string signer_pubkey = 17;
 }
 
 message GetReceiptRequest {

--- a/crates/nucleus-node/src/main.rs
+++ b/crates/nucleus-node/src/main.rs
@@ -3631,34 +3631,20 @@ impl NodeService for GrpcService {
         let pod_id_str = req.pod_id;
         let handle = pod_api::grpc_scoped_pod(&self.state, &md, &pod_id_str).await?;
 
-        let built = pod_receipt::build(&handle).await.map_err(|e| match e {
-            pod_receipt::ReceiptError::NotExited => Status::failed_precondition(e.to_string()),
-            pod_receipt::ReceiptError::NoExitReport(_) => Status::not_found(e.to_string()),
-            pod_receipt::ReceiptError::Malformed(_) => Status::internal(e.to_string()),
-        })?;
+        let built = pod_receipt::build(&handle, &self.state.authority)
+            .await
+            .map_err(|e| match e {
+                pod_receipt::ReceiptError::NotExited => Status::failed_precondition(e.to_string()),
+                pod_receipt::ReceiptError::NoExitReport(_) => Status::not_found(e.to_string()),
+                pod_receipt::ReceiptError::Malformed(_) => Status::internal(e.to_string()),
+            })?;
         // The outward-facing report stays on this transport only; see `pod_receipt`'s module docs
         // for why the HTTP route deliberately does not inherit it.
         pod_receipt::report_to_trust_gate(&self.state, &built);
         let r = built.receipt;
 
         Ok(GrpcResponse::new(proto::GetReceiptResponse {
-            receipt: Some(proto::ExecutionReceipt {
-                pod_id: r.pod_id,
-                workspace_hash: r.workspace_hash,
-                audit_tail_hash: r.audit_tail_hash,
-                audit_entry_count: r.audit_entry_count,
-                timestamp_unix: r.timestamp_unix,
-                manifest_hash: r.manifest_hash,
-                sandbox_tier: r.sandbox_tier,
-                spiffe_id: r.spiffe_id,
-                version: r.version,
-                v1_content_hash: r.v1_content_hash,
-                extensions: std::collections::HashMap::new(),
-                input_tokens: r.input_tokens,
-                output_tokens: r.output_tokens,
-                cache_read_tokens: r.cache_read_tokens,
-                cost_usd: r.cost_usd,
-            }),
+            receipt: Some(r.into()),
         }))
     }
 

--- a/crates/nucleus-node/src/pod_api.rs
+++ b/crates/nucleus-node/src/pod_api.rs
@@ -476,7 +476,7 @@ pub(crate) async fn get_receipt(
 ) -> Result<Json<crate::pod_receipt::Receipt>, ApiError> {
     use crate::pod_receipt::ReceiptError;
     let pod = get_pod_for_caller(&state, id, caller).await?;
-    match crate::pod_receipt::build(&pod).await {
+    match crate::pod_receipt::build(&pod, &state.authority).await {
         Ok(built) => Ok(Json(built.receipt)),
         // A pod that has not finished has no receipt YET, which is not the same as not having one
         // — and neither is the same as not existing. `NoExitReport` maps to NotFound because the

--- a/crates/nucleus-node/src/pod_authority.rs
+++ b/crates/nucleus-node/src/pod_authority.rs
@@ -208,6 +208,30 @@ struct Inner {
     external: HashMap<[u8; 32], BudgetLedger>,
 }
 
+/// Domain separator for pod-receipt signatures.
+///
+/// Versioned: a change to how the preimage is built is a new signature space,
+/// not a silent reinterpretation of the old one.
+const RECEIPT_DOMAIN: &[u8] = b"nucleus/pod-receipt/v1\0";
+
+/// Verify a pod-receipt signature against a node's advertised root public key.
+///
+/// Free function, not a method: a relying party has the public key and the
+/// bytes, and must not need a `PodAuthority` — which owns the PRIVATE key — to
+/// check a receipt. If verification required the signer, only the signer could
+/// verify, which is not a property anyone should accept from an attestation.
+pub(crate) fn verify_pod_receipt(pubkey_hex: &str, preimage: &[u8], signature_hex: &str) -> bool {
+    let (Ok(pubkey), Ok(sig)) = (hex::decode(pubkey_hex), hex::decode(signature_hex)) else {
+        return false;
+    };
+    let mut msg = Vec::with_capacity(RECEIPT_DOMAIN.len() + preimage.len());
+    msg.extend_from_slice(RECEIPT_DOMAIN);
+    msg.extend_from_slice(preimage);
+    ring::signature::UnparsedPublicKey::new(&ring::signature::ED25519, &pubkey)
+        .verify(&msg, &sig)
+        .is_ok()
+}
+
 /// The node's certificate authority for pods. See the module docs.
 pub(crate) struct PodAuthority {
     trust_domain: String,
@@ -290,6 +314,36 @@ impl PodAuthority {
     }
 
     /// The hex root public key delivered to pods as the pinned anchor.
+    /// Sign a pod receipt's preimage with the node's root key.
+    ///
+    /// # Why this is not `sign(&[u8])`
+    ///
+    /// The root key also mints `LatticeCertificate`s. A general signing
+    /// accessor would be an oracle: anything holding a `&PodAuthority` could
+    /// have the node sign bytes of its choosing, and a receipt preimage that
+    /// happened to parse as a certificate body would yield a signature valid as
+    /// BOTH. The domain tag makes the two languages disjoint, and keeping the
+    /// tagging inside this method means no caller can forget it.
+    ///
+    /// # Why the HOST signs a pod receipt at all
+    ///
+    /// `MediationReceipt` mints a per-pod key and serves it INTO the guest, which
+    /// is right for attesting decisions the in-guest mediator made. It is wrong
+    /// for a receipt about what a pod produced: a workload holding the key can
+    /// sign any verdict it likes. SLSA Build L3's defining property is that
+    /// signing keys are isolated from user-controlled build steps, and this key
+    /// never leaves the host — only public halves enter a guest.
+    ///
+    /// What the signature establishes is therefore narrow and worth stating: the
+    /// node, holding this key, observed these bytes. It says nothing about
+    /// whether the workload told the truth in them.
+    pub fn sign_pod_receipt(&self, preimage: &[u8]) -> String {
+        let mut msg = Vec::with_capacity(RECEIPT_DOMAIN.len() + preimage.len());
+        msg.extend_from_slice(RECEIPT_DOMAIN);
+        msg.extend_from_slice(preimage);
+        hex::encode(self.root_key.sign(&msg).as_ref())
+    }
+
     pub fn root_pubkey_hex(&self) -> String {
         hex::encode(&self.root_pubkey)
     }

--- a/crates/nucleus-node/src/pod_authority.rs
+++ b/crates/nucleus-node/src/pod_authority.rs
@@ -233,9 +233,25 @@ pub(crate) fn verify_pod_receipt(pubkey_hex: &str, preimage: &[u8], signature_he
     let mut msg = Vec::with_capacity(RECEIPT_DOMAIN.len() + preimage.len());
     msg.extend_from_slice(RECEIPT_DOMAIN);
     msg.extend_from_slice(preimage);
-    ring::signature::UnparsedPublicKey::new(&ring::signature::ED25519, &pubkey)
-        .verify(&msg, &sig)
-        .is_ok()
+
+    // `verify_strict`, NOT `ring::signature::ED25519`.
+    //
+    // ring's is COFACTORED verification, which accepts signatures that strict
+    // verification rejects — small-order and non-canonical points, so one
+    // signature can verify under more than one key. The M-3 gate
+    // (`scripts/check-verify-strict.sh`) forbids it on a production path, and
+    // caught this line. For a receipt the property is not academic: a verdict
+    // that verifies under two keys is a verdict attributable to two nodes.
+    let Ok(vk_bytes) = <[u8; 32]>::try_from(pubkey.as_slice()) else {
+        return false;
+    };
+    let (Ok(vk), Ok(sig)) = (
+        ed25519_dalek::VerifyingKey::from_bytes(&vk_bytes),
+        ed25519_dalek::Signature::from_slice(&sig),
+    ) else {
+        return false;
+    };
+    vk.verify_strict(&msg, &sig).is_ok()
 }
 
 /// The node's certificate authority for pods. See the module docs.

--- a/crates/nucleus-node/src/pod_authority.rs
+++ b/crates/nucleus-node/src/pod_authority.rs
@@ -220,6 +220,12 @@ const RECEIPT_DOMAIN: &[u8] = b"nucleus/pod-receipt/v1\0";
 /// bytes, and must not need a `PodAuthority` — which owns the PRIVATE key — to
 /// check a receipt. If verification required the signer, only the signer could
 /// verify, which is not a property anyone should accept from an attestation.
+// No production caller YET: the node signs, and the thing that verifies is a
+// relying party outside it. Stated rather than hidden — the same note
+// `snapshot_vmm::load` carries. A verifier nothing calls is still the half of
+// the pair that makes the signature checkable, and shipping the signer without
+// it would be a signature no one can test against.
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn verify_pod_receipt(pubkey_hex: &str, preimage: &[u8], signature_hex: &str) -> bool {
     let (Ok(pubkey), Ok(sig)) = (hex::decode(pubkey_hex), hex::decode(signature_hex)) else {
         return false;

--- a/crates/nucleus-node/src/pod_receipt.rs
+++ b/crates/nucleus-node/src/pod_receipt.rs
@@ -23,6 +23,12 @@
 //! is what a GET should be. The asymmetry is the bug being contained rather than spread, and it is
 //! written down here so the next person finds a decision instead of an inconsistency.
 
+// Declared HERE, not in main.rs, because this is the only thing that needs it:
+// the read-back exists so a receipt can be built for a microVM. It also keeps
+// `main.rs` off its line ceiling, which it was sitting exactly on.
+#[path = "scratch_readback.rs"]
+mod scratch_readback;
+
 use std::sync::Arc;
 
 use serde::Serialize;
@@ -166,9 +172,39 @@ pub(crate) async fn build(
     };
 
     let report_path = handle.spec.spec.work_dir.join(".nucleus-exit-report.json");
-    let report_json = tokio::fs::read_to_string(&report_path)
-        .await
-        .map_err(|e| ReceiptError::NoExitReport(format!("{}: {e}", report_path.display())))?;
+    let report_json = match tokio::fs::read_to_string(&report_path).await {
+        Ok(json) => json,
+        // A MICROVM SHARES NO DIRECTORY, so this path never existed for it.
+        //
+        // `nucleus-spec` says so outright — "A microVM has no host-directory
+        // mount and there never will be one" — which means this function has
+        // returned `NoExitReport` for every Firecracker pod since it was
+        // written. The guest's `/work` is a block device; its report is inside
+        // that image, and the host owns the image.
+        //
+        // ORDERING HAZARD, stated because it is real: the jail is removed at
+        // teardown (`FirecrackerPod::jail` is held "so teardown can remove
+        // it"). This read must happen while the jail still exists. A jail
+        // already gone reads as `Absent`, which is honest but is NOT the same
+        // as the pod having written nothing — so a receipt built too late is
+        // indistinguishable from a workload that crashed early, and that is a
+        // gap this comment is recording rather than closing.
+        Err(host_err) => match scratch_report(handle).await {
+            Some(Ok(json)) => json,
+            Some(Err(readback)) => {
+                return Err(ReceiptError::NoExitReport(format!(
+                    "{}: {host_err}; and the scratch disk: {readback}",
+                    report_path.display()
+                )));
+            }
+            None => {
+                return Err(ReceiptError::NoExitReport(format!(
+                    "{}: {host_err}",
+                    report_path.display()
+                )));
+            }
+        },
+    };
     let report: nucleus_spec::ExitReport =
         serde_json::from_str(&report_json).map_err(|e| ReceiptError::Malformed(e.to_string()))?;
 

--- a/crates/nucleus-node/src/pod_receipt.rs
+++ b/crates/nucleus-node/src/pod_receipt.rs
@@ -23,12 +23,6 @@
 //! is what a GET should be. The asymmetry is the bug being contained rather than spread, and it is
 //! written down here so the next person finds a decision instead of an inconsistency.
 
-// Declared HERE, not in main.rs, because this is the only thing that needs it:
-// the read-back exists so a receipt can be built for a microVM. It also keeps
-// `main.rs` off its line ceiling, which it was sitting exactly on.
-#[path = "scratch_readback.rs"]
-mod scratch_readback;
-
 use std::sync::Arc;
 
 use serde::Serialize;
@@ -53,6 +47,72 @@ pub(crate) struct Receipt {
     pub output_tokens: u64,
     pub cache_read_tokens: u64,
     pub cost_usd: f64,
+    /// The node's signature over [`Receipt::preimage`], and the key that made
+    /// it. Empty when this node could not sign — never a receipt that looks
+    /// signed and is not.
+    pub signature: String,
+    pub signer_pubkey: String,
+}
+
+impl Receipt {
+    /// The bytes the node signs.
+    ///
+    /// EXHAUSTIVELY DESTRUCTURED, so a field added to `Receipt` is an E0027
+    /// here until someone says whether it is committed to. The silent failure
+    /// of a digest is a field that quietly stopped counting, and this struct is
+    /// the thing a receipt is ABOUT.
+    ///
+    /// Each part is absorbed tag-separated and length-prefixed, so no two
+    /// distinct receipts share a preimage by concatenation, and nothing goes
+    /// through `Debug` — `scripts/check-preimage-dylint.sh` gates that.
+    ///
+    /// `signature` and `signer_pubkey` are deliberately NOT in it: a signature
+    /// cannot cover itself.
+    pub fn preimage(&self) -> Vec<u8> {
+        let Receipt {
+            pod_id,
+            workspace_hash,
+            audit_tail_hash,
+            audit_entry_count,
+            timestamp_unix,
+            manifest_hash,
+            sandbox_tier,
+            spiffe_id,
+            version,
+            v1_content_hash,
+            input_tokens,
+            output_tokens,
+            cache_read_tokens,
+            cost_usd,
+            signature: _,
+            signer_pubkey: _,
+        } = self;
+
+        let mut out = Vec::new();
+        let mut absorb = |tag: &str, bytes: &[u8]| {
+            out.extend_from_slice(tag.as_bytes());
+            out.push(0);
+            out.extend_from_slice(&(bytes.len() as u64).to_be_bytes());
+            out.extend_from_slice(bytes);
+        };
+        absorb("pod_id", pod_id.as_bytes());
+        absorb("workspace_hash", workspace_hash.as_bytes());
+        absorb("audit_tail_hash", audit_tail_hash.as_bytes());
+        absorb("audit_entry_count", &audit_entry_count.to_be_bytes());
+        absorb("timestamp_unix", &timestamp_unix.to_be_bytes());
+        absorb("manifest_hash", manifest_hash.as_bytes());
+        absorb("sandbox_tier", sandbox_tier.as_bytes());
+        absorb("spiffe_id", spiffe_id.as_bytes());
+        absorb("version", &version.to_be_bytes());
+        absorb("v1_content_hash", v1_content_hash.as_bytes());
+        absorb("input_tokens", &input_tokens.to_be_bytes());
+        absorb("output_tokens", &output_tokens.to_be_bytes());
+        absorb("cache_read_tokens", &cache_read_tokens.to_be_bytes());
+        // `to_bits` rather than `to_string`: a float's decimal rendering is a
+        // formatting decision, and this is a digest preimage.
+        absorb("cost_usd", &cost_usd.to_bits().to_be_bytes());
+        out
+    }
 }
 
 /// Why a receipt could not be produced.
@@ -95,7 +155,10 @@ pub(crate) struct Built {
 /// # Errors
 ///
 /// [`ReceiptError`] — still running, no exit report, or an unreadable one.
-pub(crate) async fn build(handle: &Arc<PodHandle>) -> Result<Built, ReceiptError> {
+pub(crate) async fn build(
+    handle: &Arc<PodHandle>,
+    authority: &crate::pod_authority::PodAuthority,
+) -> Result<Built, ReceiptError> {
     let id = handle.id;
     let state = handle.status().await;
     let PodState::Exited { code, .. } = state else {
@@ -103,39 +166,9 @@ pub(crate) async fn build(handle: &Arc<PodHandle>) -> Result<Built, ReceiptError
     };
 
     let report_path = handle.spec.spec.work_dir.join(".nucleus-exit-report.json");
-    let report_json = match tokio::fs::read_to_string(&report_path).await {
-        Ok(json) => json,
-        // A MICROVM SHARES NO DIRECTORY, so this path never existed for it.
-        //
-        // `nucleus-spec` says so outright — "A microVM has no host-directory
-        // mount and there never will be one" — which means this function has
-        // returned `NoExitReport` for every Firecracker pod since it was
-        // written. The guest's `/work` is a block device; its report is inside
-        // that image, and the host owns the image.
-        //
-        // ORDERING HAZARD, stated because it is real: the jail is removed at
-        // teardown (`FirecrackerPod::jail` is held "so teardown can remove
-        // it"). This read must happen while the jail still exists. A jail
-        // already gone reads as `Absent`, which is honest but is NOT the same
-        // as the pod having written nothing — so a receipt built too late is
-        // indistinguishable from a workload that crashed early, and that is a
-        // gap this comment is recording rather than closing.
-        Err(host_err) => match scratch_report(handle).await {
-            Some(Ok(json)) => json,
-            Some(Err(readback)) => {
-                return Err(ReceiptError::NoExitReport(format!(
-                    "{}: {host_err}; and the scratch disk: {readback}",
-                    report_path.display()
-                )));
-            }
-            None => {
-                return Err(ReceiptError::NoExitReport(format!(
-                    "{}: {host_err}",
-                    report_path.display()
-                )));
-            }
-        },
-    };
+    let report_json = tokio::fs::read_to_string(&report_path)
+        .await
+        .map_err(|e| ReceiptError::NoExitReport(format!("{}: {e}", report_path.display())))?;
     let report: nucleus_spec::ExitReport =
         serde_json::from_str(&report_json).map_err(|e| ReceiptError::Malformed(e.to_string()))?;
 
@@ -159,23 +192,34 @@ pub(crate) async fn build(handle: &Arc<PodHandle>) -> Result<Built, ReceiptError
         .cloned()
         .unwrap_or_default();
 
+    let mut receipt = Receipt {
+        pod_id: id.to_string(),
+        workspace_hash: report.workspace_hash.clone(),
+        audit_tail_hash: report.audit_tail_hash.clone(),
+        audit_entry_count: report.audit_entry_count,
+        timestamp_unix: report.timestamp_unix,
+        manifest_hash,
+        sandbox_tier: trust_profile.clone().unwrap_or_default(),
+        spiffe_id,
+        version: 1,
+        v1_content_hash,
+        input_tokens: report.input_tokens,
+        output_tokens: report.output_tokens,
+        cache_read_tokens: report.cache_read_tokens,
+        cost_usd: report.cost_usd,
+        // Filled below: the preimage is over the OTHER fields, so the
+        // receipt has to exist before it can be signed.
+        signature: String::new(),
+        signer_pubkey: String::new(),
+    };
+    // The node signs, not the pod. See `PodAuthority::sign_pod_receipt` for why
+    // this is the one place the MediationReceipt pattern is deliberately not
+    // followed.
+    receipt.signature = authority.sign_pod_receipt(&receipt.preimage());
+    receipt.signer_pubkey = authority.root_pubkey_hex();
+
     Ok(Built {
-        receipt: Receipt {
-            pod_id: id.to_string(),
-            workspace_hash: report.workspace_hash.clone(),
-            audit_tail_hash: report.audit_tail_hash.clone(),
-            audit_entry_count: report.audit_entry_count,
-            timestamp_unix: report.timestamp_unix,
-            manifest_hash,
-            sandbox_tier: trust_profile.clone().unwrap_or_default(),
-            spiffe_id,
-            version: 1,
-            v1_content_hash,
-            input_tokens: report.input_tokens,
-            output_tokens: report.output_tokens,
-            cache_read_tokens: report.cache_read_tokens,
-            cost_usd: report.cost_usd,
-        },
+        receipt,
         report,
         trust_bracket,
         trust_profile,
@@ -245,6 +289,37 @@ pub(crate) fn report_to_trust_gate(state: &NodeState, built: &Built) {
     });
 }
 
+/// The gRPC shape, beside the type it is a shape OF.
+///
+/// This lived inline in `main.rs`'s `get_receipt`, which is why adding two
+/// fields to `Receipt` pushed that file over its line ceiling. A mapping
+/// between a type and its wire form belongs with the type: the two lists have
+/// to stay equal, and `the_http_body_names_the_same_fields_the_proto_does`
+/// checks exactly that — from here, where both are visible.
+impl From<Receipt> for crate::proto::ExecutionReceipt {
+    fn from(r: Receipt) -> Self {
+        Self {
+            pod_id: r.pod_id,
+            workspace_hash: r.workspace_hash,
+            audit_tail_hash: r.audit_tail_hash,
+            audit_entry_count: r.audit_entry_count,
+            timestamp_unix: r.timestamp_unix,
+            manifest_hash: r.manifest_hash,
+            sandbox_tier: r.sandbox_tier,
+            spiffe_id: r.spiffe_id,
+            version: r.version,
+            v1_content_hash: r.v1_content_hash,
+            extensions: std::collections::HashMap::new(),
+            input_tokens: r.input_tokens,
+            output_tokens: r.output_tokens,
+            cache_read_tokens: r.cache_read_tokens,
+            cost_usd: r.cost_usd,
+            signature: r.signature,
+            signer_pubkey: r.signer_pubkey,
+        }
+    }
+}
+
 /// The exit report read out of a Firecracker pod's scratch image, or `None`
 /// when this pod has no such image (every other driver shares a directory and
 /// never reaches here).
@@ -291,6 +366,8 @@ mod tests {
             output_tokens: 20,
             cache_read_tokens: 5,
             cost_usd: 0.5,
+            signature: String::new(),
+            signer_pubkey: String::new(),
         }
     }
 
@@ -326,6 +403,8 @@ mod tests {
             "output_tokens",
             "cache_read_tokens",
             "cost_usd",
+            "signature",
+            "signer_pubkey",
         ]
         .into_iter()
         .collect();
@@ -588,5 +667,241 @@ mod tests {
             );
             assert!(built.trust_bracket.is_none());
         }
+    }
+}
+
+#[cfg(test)]
+mod signature_tests {
+    use super::*;
+    use crate::pod_authority::verify_pod_receipt;
+
+    fn sample() -> Receipt {
+        Receipt {
+            pod_id: "11111111-1111-1111-1111-111111111111".into(),
+            workspace_hash: "ws".into(),
+            audit_tail_hash: "tail".into(),
+            audit_entry_count: 3,
+            timestamp_unix: 1_700_000_000,
+            manifest_hash: "mh".into(),
+            sandbox_tier: "tier2".into(),
+            spiffe_id: "spiffe://nucleus.local/ns/default/sa/x".into(),
+            version: 1,
+            v1_content_hash: "v1".into(),
+            input_tokens: 10,
+            output_tokens: 20,
+            cache_read_tokens: 30,
+            cost_usd: 0.5,
+            signature: String::new(),
+            signer_pubkey: String::new(),
+        }
+    }
+
+    /// **Every committed field must move the preimage.** A field the signature
+    /// does not cover can be rewritten in flight while the signature still
+    /// verifies — the tamper a signature exists to prevent.
+    #[test]
+    fn every_field_reaches_the_preimage() {
+        let base = sample().preimage();
+        let cases: Vec<(&str, Receipt)> = vec![
+            (
+                "pod_id",
+                Receipt {
+                    pod_id: "other".into(),
+                    ..sample()
+                },
+            ),
+            (
+                "workspace_hash",
+                Receipt {
+                    workspace_hash: "other".into(),
+                    ..sample()
+                },
+            ),
+            (
+                "audit_tail_hash",
+                Receipt {
+                    audit_tail_hash: "other".into(),
+                    ..sample()
+                },
+            ),
+            (
+                "audit_entry_count",
+                Receipt {
+                    audit_entry_count: 4,
+                    ..sample()
+                },
+            ),
+            (
+                "timestamp_unix",
+                Receipt {
+                    timestamp_unix: 1_700_000_001,
+                    ..sample()
+                },
+            ),
+            (
+                "manifest_hash",
+                Receipt {
+                    manifest_hash: "other".into(),
+                    ..sample()
+                },
+            ),
+            (
+                "sandbox_tier",
+                Receipt {
+                    sandbox_tier: "tier1".into(),
+                    ..sample()
+                },
+            ),
+            (
+                "spiffe_id",
+                Receipt {
+                    spiffe_id: "spiffe://other".into(),
+                    ..sample()
+                },
+            ),
+            (
+                "version",
+                Receipt {
+                    version: 2,
+                    ..sample()
+                },
+            ),
+            (
+                "v1_content_hash",
+                Receipt {
+                    v1_content_hash: "other".into(),
+                    ..sample()
+                },
+            ),
+            (
+                "input_tokens",
+                Receipt {
+                    input_tokens: 11,
+                    ..sample()
+                },
+            ),
+            (
+                "output_tokens",
+                Receipt {
+                    output_tokens: 21,
+                    ..sample()
+                },
+            ),
+            (
+                "cache_read_tokens",
+                Receipt {
+                    cache_read_tokens: 31,
+                    ..sample()
+                },
+            ),
+            (
+                "cost_usd",
+                Receipt {
+                    cost_usd: 0.6,
+                    ..sample()
+                },
+            ),
+        ];
+        for (field, perturbed) in cases {
+            assert_ne!(
+                base,
+                perturbed.preimage(),
+                "{field} does not reach the preimage: it can be rewritten with the signature \
+                 still verifying"
+            );
+        }
+    }
+
+    /// The signature cannot cover itself, so those two fields must NOT move it —
+    /// otherwise signing would invalidate what it just signed.
+    #[test]
+    fn the_signature_fields_are_not_in_their_own_preimage() {
+        let base = sample().preimage();
+        let signed = Receipt {
+            signature: "deadbeef".into(),
+            signer_pubkey: "cafe".into(),
+            ..sample()
+        };
+        assert_eq!(base, signed.preimage());
+    }
+
+    /// **Framing must be injective.** Without the length prefixes, moving a
+    /// character across a field boundary would be the same bytes — two
+    /// different receipts under one signature.
+    #[test]
+    fn a_field_boundary_cannot_move_without_changing_the_preimage() {
+        let a = Receipt {
+            workspace_hash: "ab".into(),
+            audit_tail_hash: String::new(),
+            ..sample()
+        };
+        let b = Receipt {
+            workspace_hash: "a".into(),
+            audit_tail_hash: "b".into(),
+            ..sample()
+        };
+        assert_ne!(a.preimage(), b.preimage());
+    }
+
+    /// A signature made by a DIFFERENT key must not verify. This is what makes
+    /// the host-held key meaningful: a guest, which never sees it, cannot
+    /// produce one.
+    #[test]
+    fn another_key_cannot_sign_a_receipt_this_node_would_accept() {
+        use ring::signature::KeyPair;
+        let rng = ring::rand::SystemRandom::new();
+        let mk = || {
+            let doc = ring::signature::Ed25519KeyPair::generate_pkcs8(&rng).expect("gen");
+            ring::signature::Ed25519KeyPair::from_pkcs8(doc.as_ref()).expect("parse")
+        };
+        let node = mk();
+        let impostor = mk();
+        let node_pub = hex::encode(node.public_key().as_ref());
+        let preimage = sample().preimage();
+
+        // Same domain tag the authority uses; a signature over the bare
+        // preimage must not verify either.
+        let mut msg = b"nucleus/pod-receipt/v1\0".to_vec();
+        msg.extend_from_slice(&preimage);
+
+        let theirs = hex::encode(impostor.sign(&msg).as_ref());
+        assert!(
+            !verify_pod_receipt(&node_pub, &preimage, &theirs),
+            "a receipt signed by another key verified against this node's"
+        );
+
+        let ours = hex::encode(node.sign(&msg).as_ref());
+        assert!(
+            verify_pod_receipt(&node_pub, &preimage, &ours),
+            "the node's own did not verify"
+        );
+    }
+
+    /// **The domain tag is load-bearing.** A signature over the untagged
+    /// preimage must not verify, or a signature minted in another of the root
+    /// key's roles could be replayed as a receipt.
+    #[test]
+    fn a_signature_over_the_untagged_preimage_does_not_verify() {
+        use ring::signature::KeyPair;
+        let rng = ring::rand::SystemRandom::new();
+        let doc = ring::signature::Ed25519KeyPair::generate_pkcs8(&rng).expect("gen");
+        let key = ring::signature::Ed25519KeyPair::from_pkcs8(doc.as_ref()).expect("parse");
+        let preimage = sample().preimage();
+        let untagged = hex::encode(key.sign(&preimage).as_ref());
+        assert!(!verify_pod_receipt(
+            &hex::encode(key.public_key().as_ref()),
+            &preimage,
+            &untagged
+        ));
+    }
+
+    /// Malformed input is `false`, never a panic: a verifier is handed
+    /// attacker-controlled text by definition.
+    #[test]
+    fn malformed_signatures_are_refused_rather_than_fatal() {
+        let p = sample().preimage();
+        assert!(!verify_pod_receipt("nothex", &p, "nothex"));
+        assert!(!verify_pod_receipt("", &p, ""));
+        assert!(!verify_pod_receipt("aabb", &p, "ccdd"));
     }
 }

--- a/crates/nucleus-node/src/pod_receipt.rs
+++ b/crates/nucleus-node/src/pod_receipt.rs
@@ -457,6 +457,22 @@ mod tests {
 
         /// A pod handle whose child has actually run and exited, or is still
         /// running when `exit` is false.
+        /// A real `PodAuthority` over a temp state dir, so `build` signs for
+        /// real in these tests rather than against a stub. The key is generated
+        /// per-test, which is also what makes "another key does not verify"
+        /// meaningful.
+        fn authority(dir: &std::path::Path) -> crate::pod_authority::PodAuthority {
+            crate::pod_authority::PodAuthority::new(
+                &crate::pod_authority::AuthorityArgs {
+                    root_minter_spiffe_id: None,
+                    cert_trust_anchors: Vec::new(),
+                    max_children_per_pod: 8,
+                },
+                "nucleus.local",
+                dir,
+            )
+        }
+
         async fn pod(
             work_dir: &std::path::Path,
             exit: bool,
@@ -528,7 +544,7 @@ mod tests {
             let handle = pod(dir.path(), false, &[]).await;
             // `let Err(..) else` rather than `expect_err`: `Built` has no
             // `Debug`, and a test is not a reason to add one to a production type.
-            let Err(err) = build(&handle).await else {
+            let Err(err) = build(&handle, &authority(dir.path())).await else {
                 panic!("a running pod must not produce a receipt");
             };
             assert!(matches!(err, ReceiptError::NotExited), "{err:?}");
@@ -541,7 +557,7 @@ mod tests {
         async fn an_exited_pod_with_no_report_says_which_file_is_missing() {
             let dir = tempfile::tempdir().expect("tempdir");
             let handle = pod(dir.path(), true, &[]).await;
-            let Err(err) = build(&handle).await else {
+            let Err(err) = build(&handle, &authority(dir.path())).await else {
                 panic!("no report on disk, so no receipt");
             };
             let ReceiptError::NoExitReport(why) = err else {
@@ -560,7 +576,7 @@ mod tests {
             let dir = tempfile::tempdir().expect("tempdir");
             write_report(dir.path(), "{not json");
             let handle = pod(dir.path(), true, &[]).await;
-            let Err(err) = build(&handle).await else {
+            let Err(err) = build(&handle, &authority(dir.path())).await else {
                 panic!("malformed json must not produce a receipt");
             };
             assert!(matches!(err, ReceiptError::Malformed(_)), "{err:?}");
@@ -573,7 +589,9 @@ mod tests {
             let dir = tempfile::tempdir().expect("tempdir");
             write_report(dir.path(), REPORT);
             let handle = pod(dir.path(), true, &[]).await;
-            let built = build(&handle).await.expect("a receipt is produced");
+            let built = build(&handle, &authority(dir.path()))
+                .await
+                .expect("a receipt is produced");
 
             let r = &built.receipt;
             assert_eq!(r.pod_id, handle.id.to_string());
@@ -603,8 +621,12 @@ mod tests {
             let b = tempfile::tempdir().expect("tempdir");
             write_report(a.path(), REPORT);
             write_report(b.path(), REPORT);
-            let one = build(&pod(a.path(), true, &[]).await).await.expect("built");
-            let two = build(&pod(b.path(), true, &[]).await).await.expect("built");
+            let one = build(&pod(a.path(), true, &[]).await, &authority(a.path()))
+                .await
+                .expect("built");
+            let two = build(&pod(b.path(), true, &[]).await, &authority(b.path()))
+                .await
+                .expect("built");
 
             assert_ne!(
                 one.receipt.v1_content_hash, two.receipt.v1_content_hash,
@@ -632,7 +654,7 @@ mod tests {
                 ],
             )
             .await;
-            let built = build(&handle).await.expect("built");
+            let built = build(&handle, &authority(dir.path())).await.expect("built");
 
             assert_eq!(built.trust_bracket.as_deref(), Some("B2"));
             assert_eq!(built.trust_profile.as_deref(), Some("restricted"));
@@ -654,7 +676,7 @@ mod tests {
         async fn an_unlabelled_pod_still_names_itself() {
             let dir = tempfile::tempdir().expect("tempdir");
             write_report(dir.path(), REPORT);
-            let built = build(&pod(dir.path(), true, &[]).await)
+            let built = build(&pod(dir.path(), true, &[]).await, &authority(dir.path()))
                 .await
                 .expect("built");
             assert_eq!(


### PR DESCRIPTION
M2 step 3. `pod_receipt::Receipt` carried `v1_content_hash` — a bare SHA-256 anyone can recompute — and **no signature, and no verifier**. It said what happened and nothing said who observed it.

## Why the host signs, which is a departure

`MediationReceipt` mints a per-pod key and serves it **into the guest** over vsock. That's right for attesting decisions the in-guest mediator made. It's wrong for a receipt about what a pod produced: **a workload holding the key can sign any verdict it likes.**

SLSA Build L3's defining property is that signing keys are isolated from user-controlled build steps. `pod_authority`'s root key is persisted host-side and only *public* halves ever enter a guest — it already has that shape. This uses it.

What the signature establishes is narrow, and stated as such: *the node, holding this key, observed these bytes.* It says nothing about whether the workload told the truth in them.

## Not a signing oracle

`sign_pod_receipt` domain-tags internally rather than exposing `sign(&[u8])`. The root key also mints `LatticeCertificate`s; a general accessor would let anything holding a `&PodAuthority` have the node sign bytes of its choosing, and a receipt preimage that happened to parse as a certificate body would yield a signature valid as **both**. A test pins that a signature over the *untagged* preimage does not verify.

`verify_pod_receipt` is a **free function**, not a method. A relying party has the public key and the bytes, and must not need a `PodAuthority` — which owns the *private* key — to check a receipt. If verification required the signer, only the signer could verify.

## The preimage

Exhaustively destructured, so a new field on `Receipt` is an `E0027` until someone says whether it's committed to. Tagged and length-prefixed, no `Debug` — the discipline `check-preimage-dylint.sh` gates. `cost_usd` enters as `to_bits`, because a float's decimal rendering is a formatting decision and this is a digest.

`signature` and `signer_pubkey` bind to `_` deliberately: a signature cannot cover itself, and a test pins that setting them doesn't move the preimage.

## Seven properties

Every field moves the preimage · the two signature fields don't · framing is injective across a field boundary · another key's signature doesn't verify · an untagged signature doesn't verify · malformed hex is `false`, never a panic.

## An existing test caught the wire drift

`the_http_body_names_the_same_fields_the_proto_does` went red the moment the struct grew — the test doing its job. The HTTP body and the gRPC proto must name one vocabulary; both now carry the fields.

Moving the `ExecutionReceipt` mapping out of `main.rs` into `pod_receipt.rs` as a `From` impl is what made room under the line ceiling, and is where it belonged: the parity test compares two lists that are now both visible from one file. **main.rs: 4007 (exactly at ceiling) → 3993.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016t7JSuCtg4dC54HZjFgBjr