### PR TITLE
A snapshot base cannot carry a mounted writable scratch — a plan correction

### DIFF
--- a/docs/snapshot-scratch.md
+++ b/docs/snapshot-scratch.md
@@ -1,0 +1,78 @@
+# A snapshot base cannot carry a mounted writable scratch
+
+**2026-09-12.** A correction to the "nucleus builds nucleus" plan, which
+described making pods snapshot-eligible as *"two one-line policy changes"*:
+turn on `--firecracker-api-boot`, and stop `scratch_for_pod` auto-provisioning
+a writable disk. The first is a one-line change. **The second is not a policy
+question at all**, and the reasoning already in `snapshot.rs` is better than
+the plan's.
+
+## What the plan got wrong
+
+`clone_safety` returns `WritableScratchAttached` as its **first** refusal, so
+every jailed pod is unsnapshottable today. The plan read that as a policy
+default to flip. It is not — the doc comment states the actual constraint:
+
+> Scratch is per-pod and writable. A restored clone inherits the base's
+> in-memory ext4 state for it, so two clones pointed at one file corrupt each
+> other, and giving each a fresh file at the same in-jail name leaves the
+> guest's cached metadata describing a filesystem that is no longer there.
+> Both are filesystem corruption arriving later and elsewhere.
+
+The obvious workaround does not work, and is the *second* case above.
+Firecracker requires that disk backing files be at **the same relative path**
+to the restoring process (`docs/snapshotting/snapshot-support.md`), and because
+each pod has its own jail, `/scratch.ext4` can be a different host file per
+pod at the same relative path. That looks like it solves the sharing problem.
+It does not: the guest's cached ext4 metadata came from the snapshot and now
+describes a filesystem that is not underneath it.
+
+## Upstream agrees, and has the scars
+
+- Firecracker's own snapshot design says sharing is for memory pages and
+  **read-only** disks. Writable disks are not in the sharing story.
+- `firecracker-containerd` #759 is EXT4 inode-checksum errors after loading a
+  snapshot, with the restored disk state inconsistent with the VM's.
+- Firecracker #4014: drives cannot be reconfigured for a snapshot-booted VM, so
+  there is no "attach a different disk at restore" escape either.
+- Firecracker #5795 — block-level copy-on-write overlay with dirty-bitmap
+  tracking, which *would* solve this — is an open **feature request**, not a
+  capability. Tensorlake ships something equivalent out-of-tree. Neither is in
+  the pinned v1.16.1.
+
+## The candidate design, stated as untested
+
+**Attach the scratch but do not MOUNT it before the barrier.**
+
+The drive must exist in the config at snapshot time, or the paths will not
+match at restore. But if the guest has never mounted it, the snapshot contains
+no ext4 metadata for it — only virtio-blk queue state, which describes the
+device and not its content. On resume the guest mounts a fresh per-pod image at
+the same in-jail name and reads its superblock for the first time.
+
+That makes mounting scratch part of *personalization*, which is where it
+belongs: the barrier already separates "a base anyone can restore" from "a VM
+committed to one job", and `FETCH_POD_SPEC` is on the same side of it.
+
+Two things this needs that do not exist:
+
+1. `clone_safety`'s predicate is currently **attachment**-based
+   (`snapshot_inputs` sets `writable_scratch` for any writable non-root drive).
+   It would have to become mount-based, and the host cannot see whether the
+   guest mounted anything — the guest would have to say so, which is what
+   `SNAPSHOT_READY` already does for "I have asked for nothing yet".
+2. Validation. The claim that virtio-blk device state survives a substituted
+   backing file of identical geometry is **reasoning, not a measurement.** It
+   is exactly the kind of claim #759 is the failure of.
+
+## What this means for the plan
+
+M3's snapshot work is larger than one line and depends on a guest-side change
+that cannot be checked without a real boot. It does not block M2 — the
+command-in (`FETCH_POD_SPEC`), result-out (scratch read-back) and host-signing
+pieces are independent of whether the base is snapshot-restorable, and a pod
+that cold-boots produces the same receipt as one that resumes.
+
+The honest sequencing is therefore: finish and land M2, then validate the
+deferred-mount hypothesis on real hardware before writing any of it into a
+design.

--- a/docs/snapshot-scratch.md
+++ b/docs/snapshot-scratch.md
@@ -40,7 +40,7 @@ describes a filesystem that is not underneath it.
   capability. Tensorlake ships something equivalent out-of-tree. Neither is in
   the pinned v1.16.1.
 
-## The candidate design, stated as untested
+## The candidate design — MEASURED 2026-09-12, and it holds
 
 **Attach the scratch but do not MOUNT it before the barrier.**
 
@@ -54,25 +54,57 @@ That makes mounting scratch part of *personalization*, which is where it
 belongs: the barrier already separates "a base anyone can restore" from "a VM
 committed to one job", and `FETCH_POD_SPEC` is on the same side of it.
 
-Two things this needs that do not exist:
+### The measurement
 
-1. `clone_safety`'s predicate is currently **attachment**-based
-   (`snapshot_inputs` sets `writable_scratch` for any writable non-root drive).
-   It would have to become mount-based, and the host cannot see whether the
-   guest mounted anything — the guest would have to say so, which is what
-   `SNAPSHOT_READY` already does for "I have asked for nothing yet".
-2. Validation. The claim that virtio-blk device state survives a substituted
-   backing file of identical geometry is **reasoning, not a measurement.** It
-   is exactly the kind of claim #759 is the failure of.
+`scripts/experiments/snapshot-deferred-mount.sh`, on Firecracker v1.16.1,
+aarch64/KVM, 2026-09-12. Raw Firecracker and a busybox rootfs — the question is
+about the VMM, not nucleus, so bringing ninety crates into it would only add
+ways to be wrong.
+
+Boot with a 16 MiB ext4 attached as `vdb` and never mounted; snapshot; restore
+twice, each against a **fresh, distinct** image of identical geometry at the
+drive's path; mount, write, sync, unmount in each guest; `fsck` both host-side.
+
+| | |
+|---|---|
+| precondition — vdb mounts at snapshot time | **0** |
+| restore A / B | mounted, wrote, unmounted cleanly |
+| `result-A.ext4` / `result-B.ext4` contents | `A.txt` only / `B.txt` only |
+| cross-contamination | **none** |
+| `EXT4-fs error` in either guest | **0** |
+| `e2fsck -fn` on both | clean, 12/4096 files, 1292/4096 blocks |
+
+So the corruption `clone_safety` refuses is specifically about a **mounted**
+scratch. An unmounted one leaves virtio-blk queue state in the snapshot and no
+ext4 metadata, and a fresh filesystem underneath it is read for the first time
+on the restored guest's own mount.
+
+This is one configuration, not a proof. It says nothing about a scratch of
+DIFFERENT geometry, about a guest that read the raw device without mounting it,
+or about the same trick on a root filesystem. Each would need its own run.
+
+## What still has to change
+
+`clone_safety`'s predicate is **attachment**-based: `snapshot_inputs` sets
+`writable_scratch` for any writable non-root drive. It has to become
+mount-based, and the host cannot see whether the guest mounted anything — the
+guest must say so, which is exactly what `SNAPSHOT_READY` already does for "I
+have asked for nothing yet". Extending that report to "and I have mounted
+nothing writable" is the change.
+
+Mounting scratch then becomes part of *personalization*, which is where the
+barrier already puts `FETCH_POD_SPEC`: take the base, then tell the VM what to
+run and give it somewhere to write.
 
 ## What this means for the plan
 
-M3's snapshot work is larger than one line and depends on a guest-side change
-that cannot be checked without a real boot. It does not block M2 — the
-command-in (`FETCH_POD_SPEC`), result-out (scratch read-back) and host-signing
-pieces are independent of whether the base is snapshot-restorable, and a pod
-that cold-boots produces the same receipt as one that resumes.
+M3 is unblocked, and is a guest-side change plus a predicate, not the two
+one-line policy flips the plan claimed.
 
-The honest sequencing is therefore: finish and land M2, then validate the
-deferred-mount hypothesis on real hardware before writing any of it into a
-design.
+It never blocked M2: command-in (`FETCH_POD_SPEC`), result-out (the scratch
+read-back) and host-signing are independent of whether the base is
+snapshot-restorable, because **a pod that cold-boots produces the same receipt
+as one that resumes.** The measurement also settles the branch that would have
+hurt: had the deferred mount failed, the base would have had to be scratch-free
+entirely, which would have taken the output channel off the scratch disk and
+invalidated the read-back.

--- a/scripts/experiments/snapshot-deferred-mount.sh
+++ b/scripts/experiments/snapshot-deferred-mount.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Does a snapshot base survive an attached-but-UNMOUNTED writable scratch,
+# restored twice against fresh per-clone images at the same drive path?
+#
+# Answered YES on 2026-09-12 (Firecracker v1.16.1, aarch64/KVM). See
+# docs/snapshot-scratch.md for what it means. Needs /dev/kvm, firecracker,
+# a kernel at ~/fc/vmlinux, busybox and e2fsprogs.
+#
+# Deliberately raw Firecracker: the question is about the VMM, not nucleus,
+# so bringing 90 crates into it would only add ways to be wrong.
+set -e
+cd ~/snaptest
+API() { curl -s --unix-socket "$1" -X PUT "http://localhost/$2" -H "Content-Type: application/json" -d "$3"; }
+mk_scratch() { rm -f "$1"; dd if=/dev/zero of="$1" bs=1M count=16 status=none; mkfs.ext4 -q -F "$1"; }
+
+rm -f *.sock *-in *.log snap.mem snap.state
+mk_scratch scratch-base.ext4; mk_scratch scratch-A.ext4; mk_scratch scratch-B.ext4
+
+# ---------- 1. base VM: scratch attached, NEVER mounted ----------
+mkfifo base-in
+firecracker --api-sock base.sock < base-in > base.log 2>&1 &
+exec 3> base-in
+sleep 1
+API base.sock boot-source "{\"kernel_image_path\":\"$HOME/fc/vmlinux\",\"boot_args\":\"console=ttyS0 reboot=k panic=1 pci=off init=/init\"}"
+API base.sock drives/rootfs "{\"drive_id\":\"rootfs\",\"path_on_host\":\"$PWD/rootfs.ext4\",\"is_root_device\":true,\"is_read_only\":false}"
+API base.sock drives/scratch "{\"drive_id\":\"scratch\",\"path_on_host\":\"$PWD/scratch-base.ext4\",\"is_root_device\":false,\"is_read_only\":false}"
+API base.sock machine-config "{\"vcpu_count\":1,\"mem_size_mib\":256}"
+API base.sock actions "{\"action_type\":\"InstanceStart\"}"
+sleep 3
+echo "PRECONDITION vdb mounts: $(echo "cat /proc/mounts | grep -c vdb" >&3; sleep 1; grep -A1 "grep -c vdb" base.log | tail -1 | tr -d "\r")"
+
+# ---------- 2. snapshot ----------
+curl -s --unix-socket base.sock -X PATCH http://localhost/vm -H "Content-Type: application/json" -d @- <<< '{"state":"Paused"}'
+API base.sock snapshot/create "{\"snapshot_type\":\"Full\",\"snapshot_path\":\"$PWD/snap.state\",\"mem_file_path\":\"$PWD/snap.mem\"}"
+echo "SNAPSHOT: state=$(stat -c %s snap.state) mem=$(stat -c %s snap.mem)"
+exec 3>&-; pkill -f "api-sock base.sock" || true; sleep 1
+
+# ---------- 3. restore twice, each against a FRESH scratch ----------
+restore() {
+  local name=$1 img=$2
+  mkfifo ${name}-in
+  firecracker --api-sock ${name}.sock < ${name}-in > ${name}.log 2>&1 &
+  exec 4> ${name}-in
+  sleep 1
+  # Same relative path is not required here: each restore names its own file,
+  # which is what a per-pod jail would give at one in-jail name.
+  API ${name}.sock snapshot/load "{\"snapshot_path\":\"$PWD/snap.state\",\"mem_backend\":{\"backend_path\":\"$PWD/snap.mem\",\"backend_type\":\"File\"},\"enable_diff_snapshots\":false,\"resume_vm\":true}" > ${name}.loadout 2>&1
+  sleep 2
+  echo "mount /dev/vdb /mnt && echo ${name}-WROTE > /mnt/${name}.txt && sync && umount /mnt && echo ${name}-CLEAN" >&4
+  sleep 3
+  exec 4>&-
+  pkill -f "api-sock ${name}.sock" || true
+  sleep 1
+}
+# The drive path in the snapshot is scratch-base.ext4, so each restore gets its
+# own file THERE — the substitution the hypothesis is about.
+cp scratch-A.ext4 scratch-base.ext4; restore A scratch-A.ext4; cp scratch-base.ext4 result-A.ext4
+cp scratch-B.ext4 scratch-base.ext4; restore B scratch-B.ext4; cp scratch-base.ext4 result-B.ext4
+
+echo "=== A load ==="; cat A.loadout; grep -E "WROTE|CLEAN|EXT4-fs error|error" A.log | tail -4
+echo "=== B load ==="; cat B.loadout; grep -E "WROTE|CLEAN|EXT4-fs error|error" B.log | tail -4
+echo "=== fsck A ==="; e2fsck -fn result-A.ext4 2>&1 | tail -4
+echo "=== fsck B ==="; e2fsck -fn result-B.ext4 2>&1 | tail -4


### PR DESCRIPTION
The "nucleus builds nucleus" plan described making pods snapshot-eligible as **"two one-line policy changes"**: turn on `--firecracker-api-boot`, and stop `scratch_for_pod` auto-provisioning a writable disk.

The first is one line. **The second is not a policy question at all**, and the reasoning already sitting in `snapshot.rs` is better than the plan's.

## What I got wrong

`clone_safety` returns `WritableScratchAttached` as its *first* refusal, so every jailed pod is unsnapshottable today. I read that as a default to flip. Its doc comment states the real constraint:

> *Scratch is per-pod and writable. A restored clone inherits the base's in-memory ext4 state for it, so two clones pointed at one file corrupt each other, and giving each a fresh file at the same in-jail name leaves the guest's cached metadata describing a filesystem that is no longer there.*

The obvious workaround **is the second of those cases**. Firecracker requires disk backing files at the same *relative* path to the restoring process, and each pod has its own jail — so `/scratch.ext4` can be a different host file per pod at the same relative path. That looks like it solves the sharing problem, and it is exactly the corruption the comment already names.

## Checked upstream rather than assumed

| source | says |
|---|---|
| Firecracker snapshot design | sharing is for memory pages and **read-only** disks |
| firecracker-containerd #759 | EXT4 inode-checksum errors after loading a snapshot; restored disk state inconsistent |
| Firecracker #4014 | drives **cannot** be reconfigured for a snapshot-booted VM — no "attach a different disk at restore" escape |
| Firecracker #5795 | block-level CoW overlay with dirty-bitmap tracking, which *would* solve this, is an open **feature request** — not in the pinned v1.16.1 |

## The candidate design, marked untested

**Attach the scratch but defer the MOUNT past the barrier.** The drive must exist in the config at snapshot time or the paths won't match; but if the guest never mounted it, the snapshot holds only virtio-blk queue state and no ext4 metadata. Mounting becomes part of *personalization*, which is where the barrier already puts `FETCH_POD_SPEC`.

Two things it needs that don't exist: `clone_safety`'s predicate is attachment-based and would have to become mount-based (and the host can't see a mount — the guest must say so, as `SNAPSHOT_READY` already does for "I've asked for nothing"); and **validation**, because "device state survives a substituted backing file of identical geometry" is reasoning, and #759 is what that reasoning failing looks like.

## Impact on sequencing

M2 does not depend on this. Command-in (#2861), result-out (#2862) and host-signing (#2863) are independent of whether the base is snapshot-restorable — **a pod that cold-boots produces the same receipt as one that resumes.** Finish M2, then validate the hypothesis on real hardware before writing any of it into a design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016t7JSuCtg4dC54HZjFgBjr