### PR TITLE
The line that explains a failed verify interpolated an empty string

### DIFF
--- a/.github/actions/gatehouse/gatehouse.sh
+++ b/.github/actions/gatehouse/gatehouse.sh
@@ -106,7 +106,20 @@ jq -c .inclusion <<<"$PUSH" > "$W/proof.json"
 curl -sSf --max-time 30 "$CONTROL/v1/$TENANT/trust" > "$W/trust.json"
 "$GATE" expect "$W/gate.json" --repo . --tree HEAD --class optional --plan "$PLAN" --out "$W/expect.json" >/dev/null
 set +e
-VOUT="$("$GATE" receipt verify "$W/receipt.json" --trust "$W/trust.json" --expect "$W/expect.json" --inclusion "$W/proof.json")"; VC=$?
+# `2>&1`, and the reason is the one line this script exists to print. `$(...)` captures
+# stdout; `gate receipt verify` writes its diagnosis to STDERR. So the `die` below -- the
+# single place designed to explain why a receipt could not be checked -- interpolated an
+# empty string, while the explanation went past it into the raw log as an unattributed line.
+#
+# Seen 2026-09-12 on PR #2865's fmt shadow: the job reported
+#
+#   could not look: ProofNotAtCheckpoint { proof_size: 693, trusted_size: 694 }
+#   ##[error]gatehouse: could not verify the receipt against the log:
+#
+# -- the answer and the question, adjacent and unconnected, the error naming nothing. Inside
+# a folded log group the first line is easy to miss entirely, and then a red that says
+# exactly what happened reads as a red that says nothing.
+VOUT="$("$GATE" receipt verify "$W/receipt.json" --trust "$W/trust.json" --expect "$W/expect.json" --inclusion "$W/proof.json" 2>&1)"; VC=$?
 set -e
 case "$VC" in
   0) VERIFIED=true; HELD=held ;;


### PR DESCRIPTION
`$(...)` captures stdout. `gate receipt verify` writes its diagnosis to **stderr**. So the one `die` in `gatehouse.sh` designed to say *why* a receipt could not be checked printed nothing after the colon, while the explanation went past it into the raw log as an unattributed line.

Seen on **#2865**'s fmt shadow, two adjacent lines:

```
could not look: ProofNotAtCheckpoint { proof_size: 693, trusted_size: 694 }
##[error]gatehouse: could not verify the receipt against the log:
```

The answer and the question, next to each other, unconnected. Inside a folded log group the first is easy to miss — and then a red that says exactly what happened reads as a red that says nothing. Same failure as gatehouse **F-100** one level up: a stream nobody read, and a report built from the stream that was.

Reproduced standalone, before and after:

```
before=[]
after=[could not look: ProofNotAtCheckpoint { proof_size: 693, trusted_size: 694 }]
```

## The underlying red, for the record

It is real and correctly **informational** — the check's own name says *"red = could not look, never disagreement"*, and that is exactly what happened.

`proof_size: 693, trusted_size: 694` is a **race**: the inclusion proof arrives with the receipt POST, the trust root comes from a second request, and a concurrent job moved the checkpoint between the two. With thirteen PRs running shadow gates against one control plane that is not rare. Where it gets fixed is gatehouse's verifier — whether a proof at 693 should verify against a checkpoint at 694, which it should, a prefix being a prefix — not here. What belongs here is saying so out loud.

`bash -n` 0, `shellcheck -S error` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)