### PR TITLE
Two follow-ups to #2825: the wasm-closure probe, and the coupling its arithmetic rests on

### DIFF
--- a/crates/xtask/src/gate_budget.rs
+++ b/crates/xtask/src/gate_budget.rs
@@ -151,6 +151,21 @@ pub struct Site {
 }
 
 impl Site {
+    /// How many times the command runs under `timeout_s`.
+    ///
+    /// **This counts on something the action must do, and saying so here is the point.**
+    /// `runs = 2` is only arithmetic about a real bound if BOTH invocations are actually
+    /// bounded — the runner AND the plain `compare` run. `gatehouse.sh` bounds both, and
+    /// that change shipped in the same pull request as this gate purely because one author
+    /// wrote both. They are separate facts.
+    ///
+    /// If the compare run ever loses its bound, this stays green while the second run is
+    /// unbounded — the gate would be checking an arithmetic whose operands no longer
+    /// describe anything, which is the failure gatehouse F-103 records after nucleus #2856
+    /// arrived with a better outer-deadline fix that did not bound the compare run.
+    ///
+    /// A reader who changes `gatehouse.sh` should change this model with it, or explain why
+    /// it still holds.
     pub fn runs(&self) -> u64 {
         if self.compare { 2 } else { 1 }
     }

--- a/scripts/check-gates-can-fail.sh
+++ b/scripts/check-gates-can-fail.sh
@@ -738,6 +738,17 @@ perturb_gate_budget_timeout() {
     sed -i.bak -E 's/^( *)timeout: "[0-9]+"/\1timeout: "9999"/' "$1" && rm -f "$1.bak"
 }
 
+perturb_wasm_closure_forbid_present() {
+    # "needs a non-wasm dependency added" is true, and it is not the only thing this
+    # gate decides. It also decides, for each crate in its committed FORBIDDEN list,
+    # whether that crate is in the wasm32 closure -- and THAT detection is the fragile
+    # half: a `grep -qE "(^|[│├└─ ])${c} v[0-9]"` over `cargo tree` output, keyed on box
+    # drawing characters. If cargo ever changes that format the gate passes forever and
+    # nothing says so. Declaring a crate that IS present exercises exactly that path.
+    # `serde` is in the closure by inspection; matches the ARRAY, never a crate name.
+    sed -i.bak -E 's/^FORBIDDEN=\((.*)\)$/FORBIDDEN=(\1 serde)/' "$1" && rm -f "$1.bak"
+}
+
 perturb_dep_ceiling_raise() {
     # The OTHER direction of this gate, and the one its uncovered entry did not see.
     # "needs a real duplicate crate version" is true for the drift half -- you cannot
@@ -794,6 +805,8 @@ probe check-line-ratchet.sh   "--strict" crates/portcullis/src/kernel.rs \
       "400 lines past the ceiling"            perturb_line_ratchet
 probe check-dep-ceiling.sh    "" scripts/check-dep-ceiling.sh \
       "a ceiling above the count it caps"     perturb_dep_ceiling_raise
+probe check-wasm-closure.sh   "" scripts/check-wasm-closure.sh \
+      "a crate forbidden that is in the closure" perturb_wasm_closure_forbid_present
 probe check-law-mechanisms.sh "" crates/portcullis/src/lattice.rs \
       "a declared-dead mechanism gains a production call site" perturb_law_mechanism_wired
 probe check-law-mechanisms.sh "" crates/portcullis/src/budget.rs \
@@ -891,7 +904,6 @@ probe check-kani-divergence.sh "" crates/portcullis/src/capability.rs \
 # A perturbation for these needs a duplicate crate version or a non-wasm
 # dependency — a real lockfile change, which this script will not make.
 UNCOVERED=(
-    "check-wasm-closure.sh         needs a non-wasm dependency added"
     # 2026-09-11: the xtask half of the domain became VISIBLE today. These eight
     # were never exempted by decision — they were outside the glob, so nothing
     # asked. Listing them is the point: each now owes a perturbation or a reason,
@@ -931,7 +943,13 @@ UNCOVERED=(
 # ceiling, and raising a ceiling above the actual count exercises that half from a
 # committed declaration. The same shape as scoreboard-ratchet above: the exemption
 # named a real obstacle and stopped there.
-UNCOVERED_CEILING=6
+#
+# 2026-09-12, 6 -> 5: `check-wasm-closure.sh` gets a probe, by the same reading that
+# freed the previous two. "Needs a non-wasm dependency added" is true of the CLOSURE
+# half and silent about the DETECTION half -- a grep over `cargo tree` keyed on box
+# drawing characters, which would pass forever if cargo changed its output. Declaring
+# a present crate forbidden exercises that path from a committed list.
+UNCOVERED_CEILING=5
 
 # ── Self-falsified elsewhere, not here ────────────────────────────────────
 #


### PR DESCRIPTION
Both were written while #2825 was in flight and held because they touched files it owned. It has landed, so here they are, rebased onto it.

## `check-wasm-closure.sh` gets a probe — `UNCOVERED_CEILING` 6 → 5

The exemption read *"needs a non-wasm dependency added"*. True, and **it is not the only thing the gate decides.** For each crate in its committed `FORBIDDEN` list it also decides whether that crate is in the wasm32 closure — and **that** half is the fragile one:

```
grep -qE "(^|[│├└─ ])${c} v[0-9]"
```

a match over `cargo tree` output keyed on box-drawing characters. If cargo ever changes that format the gate passes forever and nothing says so.

The perturbation declares a crate that **is** present (`serde`, in the closure by inspection) and exercises exactly that path — no lockfile change, which is what the exemption said was needed. Fourth instance of the same shape as F-99/F-104: **the obstacle named the gate's subject and never touched its detection.**

Driven red by hand before the suite: baseline 0, perturbed **1**, restored 0.

## The `runs = 2` coupling, written where the model is

`need_s()` multiplies the declared timeout by the number of runs, and `runs = 2` when `compare` is on. That is only arithmetic about a *real* bound if **both** invocations are bounded — the runner and the plain compare run. #2825 bounds both, in `gatehouse.sh` lines 91 and 137, and that change shipped in the same PR as the gate purely because one author wrote both. They are separate facts and nothing said so.

`#2856` made the separation concrete: it fixed the same defect with a better outer deadline and did **not** bound the compare run. Run against that branch the gate red correctly — but the arithmetic behind the red was true only because of a change that branch did not contain. Recorded as gatehouse F-103.

No behaviour change; a doc comment naming the dependency and the failure it produces if the bound is ever removed.

## Verification — exit codes, never tails

| | rc |
|---|---|
| `check-wasm-closure.sh` baseline · perturbed · restored | 0 · **1** · 0 |
| `scripts/check-gates-can-fail.sh` | **0** — 41 probed, 5 uncovered (ceiling 5), 0 unaccounted |
| `cargo test -p xtask gate_budget` | 0 — 23 passed |
| `cargo clippy --all-targets -D warnings` · `cargo fmt --check` | 0 · 0 |
| `cargo xtask gate-budget` on main | 0 — `job 2700s, gate 1200s x2 + 120s slack + 60s setup = 2580s` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
