### PR TITLE
Say which gatehouse the shadow job built, so a stale pin is not read as a defect

### DIFF
--- a/.github/workflows/gatehouse-shadow.yml
+++ b/.github/workflows/gatehouse-shadow.yml
@@ -115,6 +115,31 @@ jobs:
       - name: Build gate and gatehouse-runner
         if: steps.tok.outputs.present == 'true'
         run: cargo build --locked --manifest-path gatehouse/Cargo.toml -p gate -p gatehouse-runner
+
+      # WHICH gatehouse this job just built, in the log and in the summary.
+      #
+      # Nothing here said. The step below prints the tenant and the signing key and then a
+      # verdict, and a reader who sees `the runner did not finish within 1320s` has no way to
+      # tell a live defect from a pin this branch has not picked up yet. Measured 2026-09-12:
+      # every clippy-shadow red open at the time was a branch still on GATEHOUSE_REF 7326bfa9,
+      # whose runner deadlocks reading a pipe (gatehouse F-100); main moved to 89f7acc in #2857
+      # and every run on it succeeds in about eight minutes. The two are indistinguishable in
+      # the log, and hours went into treating the first as the second.
+      #
+      # `git rev-parse` rather than echoing the variable: the variable is what was ASKED for,
+      # this is what the checkout actually produced, and when those differ the difference is
+      # the whole answer.
+      - name: Which gatehouse
+        if: steps.tok.outputs.present == 'true'
+        env:
+          WANTED: ${{ env.GATEHOUSE_REF }}
+        run: |
+          BUILT="$(git -C gatehouse rev-parse HEAD)"
+          echo "gatehouse: built $BUILT (GATEHOUSE_REF asked for $WANTED)"
+          echo "gatehouse: built \`$BUILT\`" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$BUILT" != "$WANTED" ]; then
+            echo "::warning::the checkout resolved to $BUILT, not the pinned $WANTED"
+          fi
       - name: The gate, the gatehouse way, verified against the hosted log
         if: steps.tok.outputs.present == 'true'
         id: gh


### PR DESCRIPTION
Nothing in this job said. It prints the tenant and the signing key, then a verdict, and a reader who sees

```
gatehouse: the runner did not finish within 1320s and was killed
```

has no way to tell a live defect from a pin this branch has not picked up.

## What that cost

Measured today. **Every clippy-shadow red open at the time — #2859, #2861, #2862, #2864, #2865 — was a branch still on `GATEHOUSE_REF: 7326bfa9`**, whose runner deadlocks reading a pipe (gatehouse F-100: one reader thread takes stdout to EOF then stderr, cargo writes to stderr, the 64 KiB pipe fills).

**#2857 moved main to `89f7acc` at 01:29Z**, and every shadow run on a branch carrying that ref has succeeded since — in **about eight minutes**, rather than being bounded at 2220s:

| ref | outcome |
|---|---|
| `7326bfa9` (the five red branches) | hang, bounded, no verdict |
| `89f7acc` (current main) | **success, ~8 min** |

The two are indistinguishable in the log, and this session spent hours treating the first as the second — carrying *"the clippy shadow is permanently red"* as a live finding across several rounds when the fix had already landed and the branches simply predated it.

Those branches were **5 to 9 commits behind**, so the standing *">10 commits behind, test staleness"* heuristic never fired. That threshold is a proxy: what mattered was **one commit, not a count**. A branch five behind that is missing the one commit that matters is staler, for this purpose, than a branch twenty behind that has it.

## The change

`git rev-parse` rather than echoing the variable, deliberately: the variable is what was **asked for**, this is what the checkout **produced**, and when they differ that difference is the whole answer. A mismatch warns rather than fails — this lane is informational and a warning is the strongest thing it should say.

`actionlint` 0 · `check-ci-spec.sh` 0 · `gate-budget` 0 · `gatehouse-pin` 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)