### PR TITLE
A base frozen at the mount barrier saves ~2.2 s of a ~3.35 s pod create

### DIFF
--- a/docs/snapshot-ci-budget.md
+++ b/docs/snapshot-ci-budget.md
@@ -1,0 +1,105 @@
+# What a snapshot restore can actually save on a CI pod
+
+**2026-09-12.** Measured on `nucleus-kvm` (Lima, aarch64, Firecracker v1.16.1,
+`/dev/kvm`), booting the same pod three times with `--firecracker-api-boot` on.
+This is the timing half of the snapshot question; [snapshot-scratch.md] is the
+correctness half.
+
+[snapshot-scratch.md]: ./snapshot-scratch.md
+
+## The measurement
+
+Three cold `POST /v1/pods`, same spec, digests pinned:
+
+| wall | `proxy.health_wait` | `attestation.hash` | everything else |
+|-----:|--------------------:|-------------------:|----------------:|
+| 3347 | 3132 | 176 | 39 |
+| 3521 | 3133 | 175 | 213 |
+| 3524 | 3127 | 175 | 222 |
+
+`vmm.preflight`, `prepare_jail`, `firecracker.spawn`, `seccomp.wait`,
+`vsock.wait` and `cert.issue` each measured **0 ms** in all three.
+
+## What it says
+
+**94% of pod create is waiting for the in-guest tool-proxy to answer a health
+check.** The microVM itself is up in about 200 ms; the remaining ~3.13 s is
+`wait_for_proxy_health` polling at 100 ms intervals — about 31 polls, so this
+is real in-guest startup, not a fixed sleep. The guest's own trace agrees and
+locates it: `nucleus-startup-trace total=697ms … vsock_bind=1ms`, so
+`guest-init` finishes in ~700 ms and the tool-proxy spends roughly 2.4 s more
+before it reports healthy.
+
+The consequence for the "nucleus builds nucleus" plan is direct, and it is not
+what the plan assumed:
+
+> **A 17 ms restore removes at most ~200 ms of a ~3.4 s pod create — under 6%
+> — unless the base is taken PAST the point where the proxy is healthy.**
+
+The 17 ms figure in `snapshot_restore.rs` is a real measurement of *VMM* restore
+(10 ms load + 6 ms resume vs ~79 ms cold boot). It is not wrong. It is just
+measuring the part of pod create that was already nearly free. Optimising the
+VMM further is optimising 6% of the wall clock; the other 94% is in-guest
+process startup, which a snapshot captures **only if the barrier sits after
+it**.
+
+That makes barrier placement the design question, not an implementation
+detail. A base frozen at the mount barrier — before `/work` and before
+personalisation, which is where `clone_safety` can certify it — is frozen
+*before* the tool-proxy is healthy, and therefore saves the cheap 200 ms and
+none of the expensive 3.13 s.
+
+## The two refusals a CI pod meets today, in order
+
+Both are correct, and both were reached by trying it rather than reading it.
+
+**1. No program identity.** `POST /v1/pods/{id}/snapshot` on a pod whose image
+carries no digests:
+
+```
+this pod names an image but pins no digest for it, so its program has no
+stable identity — set image.kernel_digest and image.rootfs_digest
+```
+
+`program_digest` refusing an unpinned image, exactly as designed. Pinning
+`kernel_digest` and `rootfs_digest` clears it.
+
+**2. A writable scratch — even when the spec declares none.**
+
+```
+refusing to snapshot this microVM: this microVM has a writable scratch disk,
+which clones cannot share and cannot be given fresh without stranding the
+guest's cached filesystem state
+```
+
+This one is worth stating precisely, because it is easy to read as a spec
+problem and it is not: **the pod spec declared no `scratch_path` at all.**
+`scratch_for_pod` provisions one for every *jailed* pod, so a jailed pod always
+has a writable scratch, `clone_safety` always sees one, and **no base can be
+published on the live path today**. Every pod cold-boots, which is what the
+table above measures.
+
+## What this changes about what to do next
+
+1. **Measure the 3.13 s before optimising the 200 ms.** Whatever the tool-proxy
+   is doing between `vsock_bind` and its first healthy response is the budget.
+   Nothing here has looked at it yet.
+2. **A base is only worth taking where it captures that time.** Freezing at the
+   mount barrier is the safe place and the cheap place; those are not the same
+   place, and the plan treated them as one.
+3. **Publishing a base at all needs the scratch question answered first** —
+   `snapshot-scratch.md` argues it is a real constraint rather than a default to
+   flip, and this measurement does not weaken that argument.
+
+## Reproducing
+
+```sh
+# in the KVM host, node running with --firecracker-api-boot
+nucleus node --url https://127.0.0.1:9900 create pod-with-pinned-digests.yaml
+# then, with a client cert minted from the node's CA:
+curl -sSk --cert cli-cert.pem --key cli-key.pem \
+  -X POST https://127.0.0.1:9900/v1/pods/<id>/snapshot
+```
+
+The boot breakdown is emitted by the node at `INFO` on the `boot_trace` target,
+one line per pod create.

--- a/docs/snapshot-ci-budget.md
+++ b/docs/snapshot-ci-budget.md
@@ -22,32 +22,50 @@ Three cold `POST /v1/pods`, same spec, digests pinned:
 
 ## What it says
 
-**94% of pod create is waiting for the in-guest tool-proxy to answer a health
-check.** The microVM itself is up in about 200 ms; the remaining ~3.13 s is
-`wait_for_proxy_health` polling at 100 ms intervals — about 31 polls, so this
-is real in-guest startup, not a fixed sleep. The guest's own trace agrees and
-locates it: `nucleus-startup-trace total=697ms … vsock_bind=1ms`, so
-`guest-init` finishes in ~700 ms and the tool-proxy spends roughly 2.4 s more
-before it reports healthy.
+**94% of pod create is spent in `proxy.health_wait`.** But that stage is not
+"the proxy is slow" — it is *the host waiting for the guest to finish booting*,
+because the host starts polling at +214 ms and the guest has not finished its
+kernel by then. Reading the guest console against the host clock decomposes it:
 
-The consequence for the "nucleus builds nucleus" plan is direct, and it is not
-what the plan assumed:
+| phase | guest kernel clock | duration |
+|---|---|---:|
+| kernel boot (`0.000` → `Run /init as init process`) | 0.000 → 1.534 | **1.53 s** |
+| `guest-init` (→ `[workload]`) | 1.534 → 2.598 | **1.06 s** |
+| tool-proxy until it answers healthy | 2.598 → ~3.35 | **~0.75 s** |
 
-> **A 17 ms restore removes at most ~200 ms of a ~3.4 s pod create — under 6%
-> — unless the base is taken PAST the point where the proxy is healthy.**
+Those sum to 3.34 s against a 3.35 s host wall, so the decomposition is
+complete — there is no unexplained remainder.
 
-The 17 ms figure in `snapshot_restore.rs` is a real measurement of *VMM* restore
-(10 ms load + 6 ms resume vs ~79 ms cold boot). It is not wrong. It is just
-measuring the part of pod create that was already nearly free. Optimising the
-VMM further is optimising 6% of the wall clock; the other 94% is in-guest
-process startup, which a snapshot captures **only if the barrier sits after
-it**.
+### What a restore actually replaces
 
-That makes barrier placement the design question, not an implementation
-detail. A base frozen at the mount barrier — before `/work` and before
-personalisation, which is where `clone_safety` can certify it — is frozen
-*before* the tool-proxy is healthy, and therefore saves the cheap 200 ms and
-none of the expensive 3.13 s.
+A VM snapshot restores memory and vCPU state, so the guest **resumes at the
+frozen point and does not re-run its kernel**. A base frozen at the mount
+barrier — `vsock_bind`, 669 ms into `guest-init`, so kernel clock ≈ 2.20 s —
+skips everything before it:
+
+> **~2.2 s of a ~3.35 s pod create, or about two thirds.** What remains is the
+> ~0.75 s the tool-proxy spends becoming healthy, plus ~0.2 s of host-side
+> work.
+
+The `17 ms restore vs ~79 ms cold boot` figure in `snapshot_restore.rs` is a
+VMM-level measurement — how long the *VMM* takes to start. It is correct and it
+is not the interesting number. The interesting number is the guest boot the
+restore skips entirely, which is 30× larger than the VMM difference.
+
+### A correction
+
+The first version of this document concluded the opposite — that a restore
+"removes at most ~200 ms, under 6%". That was wrong, and wrong in the way that
+would have redirected effort away from the thing worth doing. It treated
+`proxy.health_wait` as irreducible in-guest proxy startup because the stage is
+named after the proxy. It is named after what the host is polling, not after
+what the guest is doing, and for the first 2.2 s of it the guest is booting.
+
+The lesson is narrow and worth keeping: **a stage name describes the waiter,
+not the work.** The host-side breakdown alone could not distinguish "the proxy
+takes 3.1 s" from "the guest takes 3.1 s to reach a proxy that then answers
+quickly"; only the guest console could, and those two readings imply opposite
+optimisations.
 
 ## The two refusals a CI pod meets today, in order
 
@@ -81,15 +99,18 @@ table above measures.
 
 ## What this changes about what to do next
 
-1. **Measure the 3.13 s before optimising the 200 ms.** Whatever the tool-proxy
-   is doing between `vsock_bind` and its first healthy response is the budget.
-   Nothing here has looked at it yet.
-2. **A base is only worth taking where it captures that time.** Freezing at the
-   mount barrier is the safe place and the cheap place; those are not the same
-   place, and the plan treated them as one.
-3. **Publishing a base at all needs the scratch question answered first** —
-   `snapshot-scratch.md` argues it is a real constraint rather than a default to
-   flip, and this measurement does not weaken that argument.
+1. **A base frozen at the mount barrier is worth ~2.2 s per pod** — two thirds
+   of pod create. The barrier is the place `clone_safety` can certify, and it
+   is also, contrary to this document's first version, the place worth
+   freezing. They are the same place after all.
+2. **The residual target is the tool-proxy's ~0.75 s**, which a barrier
+   snapshot does not capture because the barrier precedes it. That is the
+   second-order optimisation, worth roughly a third of what the snapshot is.
+3. **None of it is reachable until a base can be published at all.**
+   `scratch_for_pod` provisions a writable scratch for every jailed pod, so
+   `clone_safety` refuses every one of them — see refusal 2 below, and
+   `snapshot-scratch.md` for why that constraint is real rather than a default
+   to flip.
 
 ## Reproducing
 

--- a/docs/snapshot-ci-budget.md
+++ b/docs/snapshot-ci-budget.md
@@ -82,7 +82,7 @@ stable identity — set image.kernel_digest and image.rootfs_digest
 `program_digest` refusing an unpinned image, exactly as designed. Pinning
 `kernel_digest` and `rootfs_digest` clears it.
 
-**2. A writable scratch — even when the spec declares none.**
+**2. A writable scratch — and the reason is not the obvious one.**
 
 ```
 refusing to snapshot this microVM: this microVM has a writable scratch disk,
@@ -90,27 +90,61 @@ which clones cannot share and cannot be given fresh without stranding the
 guest's cached filesystem state
 ```
 
-This one is worth stating precisely, because it is easy to read as a spec
-problem and it is not: **the pod spec declared no `scratch_path` at all.**
-`scratch_for_pod` provisions one for every *jailed* pod, so a jailed pod always
-has a writable scratch, `clone_safety` always sees one, and **no base can be
-published on the live path today**. Every pod cold-boots, which is what the
-table above measures.
+The obvious reading — `scratch_for_pod` provisions a scratch, and any scratch
+is refused — is wrong. `clone_safety` was changed at exactly that point:
+
+> `ATTACHED is fine; MOUNTED is not` … This *was* "is a writable non-root drive
+> attached", which refused every jailed pod.
+
+The refusal above is `Mounted`, not "attached". The pod had booted fully, and a
+booted pod has mounted `/work`. So the real question is **whether anything can
+observe the VM while it is still at its barrier** — and today nothing can:
+
+1. `guest-init` announces `SNAPSHOT_READY` and **does not stop**.
+   `announce_snapshot_ready` is best-effort by design: "announcing a barrier is
+   not a request for anything."
+2. The host's handler declines to act on it, explicitly:
+   > **Recorded, not acted on.** Taking the snapshot here would make every boot
+   > wait on a decision only the operator has, so the guest is told to carry on
+   > and the host keeps the fact for whoever asks to snapshot later.
+3. So `at_snapshot_barrier` latches true, the guest proceeds to mount `/work`,
+   and the operator's `POST /v1/pods/{id}/snapshot` — the only way to publish a
+   base — necessarily arrives *after* the mount.
+
+`clone_safety` is therefore **structurally unsatisfiable on the live path** for
+any pod with a scratch, which is every jailed pod. Not because the check is
+wrong, but because the only certifiable instant is one nothing is positioned to
+catch. A synchronisation point does exist — the guest blocks reading the reply
+to `SNAPSHOT_READY`, deliberately, "the content is not interesting, the
+ordering is" — and the handler declines to use it, for a stated reason.
+
+On `origin/main` it is not even a race: `/work` mounts at
+`crates/nucleus-guest-init/src/main.rs:132`, *before* the pod spec is resolved,
+so the barrier is announced with the scratch already mounted. #2867 moves that
+mount past the barrier and is still in the merge queue.
 
 ## What this changes about what to do next
 
-1. **A base frozen at the mount barrier is worth ~2.2 s per pod** — two thirds
-   of pod create. The barrier is the place `clone_safety` can certify, and it
-   is also, contrary to this document's first version, the place worth
-   freezing. They are the same place after all.
-2. **The residual target is the tool-proxy's ~0.75 s**, which a barrier
-   snapshot does not capture because the barrier precedes it. That is the
-   second-order optimisation, worth roughly a third of what the snapshot is.
-3. **None of it is reachable until a base can be published at all.**
-   `scratch_for_pod` provisions a writable scratch for every jailed pod, so
-   `clone_safety` refuses every one of them — see refusal 2 below, and
-   `snapshot-scratch.md` for why that constraint is real rather than a default
-   to flip.
+1. **A base frozen at the mount barrier is worth ~2.2 s per pod**, two thirds
+   of pod create. The barrier is both where `clone_safety` can certify and
+   where the saving is — contrary to this document's first version, the same
+   place.
+2. **Nothing can currently freeze there.** One of two things has to change, and
+   it is a design choice rather than a flag:
+   - a pod mode that **halts at the barrier** awaiting a snapshot decision — an
+     explicit "build me a base" pod, paying the wait once rather than on every
+     boot, which is the cost the handler's comment is refusing; or
+   - deferring the `/work` mount to **first use** rather than to immediately
+     past the barrier, so a pod that never touches `/work` stays certifiable
+     for as long as it stays untouched.
+
+   The second is the better shape: no new mode, and an ordinary pod becomes
+   usable as a base rather than needing one built for the purpose.
+3. **#2867 is a prerequisite either way** — without it the mount happens before
+   the barrier is announced at all.
+4. **The residual after a barrier snapshot is the tool-proxy's ~0.75 s**, which
+   a barrier-frozen base does not capture. Second-order target, worth about a
+   third of what the snapshot is.
 
 ## Reproducing
 


### PR DESCRIPTION
Phase 2 of "nucleus builds nucleus" is *"optimize caching, checkpoints, snapshots, and COW to make this SOTA fast"*. Before optimising, I measured where the time goes.

> **Note:** the first version of this PR concluded the opposite — that a restore saves "under 6%". That was wrong; the correction is below and is the reason this PR exists in its current form.

## The measurement

Three cold `POST /v1/pods` on `nucleus-kvm` (aarch64, Firecracker v1.16.1, `/dev/kvm`), same spec, digests pinned, `--firecracker-api-boot` on:

| wall | `proxy.health_wait` | `attestation.hash` | everything else |
|-----:|--------------------:|-------------------:|----------------:|
| 3347 | 3132 | 176 | 39 |
| 3521 | 3133 | 175 | 213 |
| 3524 | 3127 | 175 | 222 |

`vmm.preflight`, `prepare_jail`, `firecracker.spawn`, `seccomp.wait`, `vsock.wait`, `cert.issue` — **0 ms each, in all three**.

## What `proxy.health_wait` actually is

94% of pod create sits in one stage named after the proxy. It is **not** in-guest proxy startup — it is the host waiting for the guest to finish booting, because the host begins polling at +214 ms and the guest has not finished its kernel by then. Reading the guest console against the host clock decomposes it completely:

| phase | guest kernel clock | duration |
|---|---|---:|
| kernel boot (`0.000` → `Run /init as init process`) | 0.000 → 1.534 | **1.53 s** |
| `guest-init` (→ `[workload]`) | 1.534 → 2.598 | **1.06 s** |
| tool-proxy until it answers healthy | 2.598 → ~3.35 | **~0.75 s** |

3.34 s against a 3.35 s host wall — no unexplained remainder.

## What a restore replaces

A restore resumes from frozen memory and vCPU state, so the guest **does not re-run its kernel**. A base frozen at the mount barrier — `vsock_bind`, 669 ms into `guest-init`, kernel clock ≈ 2.20 s — skips everything before it:

> **~2.2 s of ~3.35 s, about two thirds.**

The `17 ms vs ~79 ms` figure in `snapshot_restore.rs` is a VMM-level measurement and is correct. It just isn't the interesting number: the guest boot a restore skips is ~30× larger than the VMM difference.

## The correction, and why it matters

The first version treated `proxy.health_wait` as irreducible proxy time *because the stage is named after the proxy*. It is named after what the host is polling, not what the guest is doing.

That error also reversed a design claim. The first version said the safe place to freeze (the mount barrier, where `clone_safety` can certify a base) and the place worth freezing were different places. **They are the same place.**

The lesson is narrow and worth keeping: **a stage name describes the waiter, not the work.** The host-side breakdown alone cannot distinguish "the proxy takes 3.1 s" from "the guest takes 3.1 s to reach a proxy that then answers quickly" — and those readings imply opposite optimisations. Only the guest console separates them.

## The two refusals a CI pod meets today

Both correct; both found by trying rather than reading.

**1.** `this pod names an image but pins no digest for it, so its program has no stable identity` — `program_digest` refusing an unpinned image. Pinning clears it.

**2.** `refusing to snapshot this microVM: this microVM has a writable scratch disk…`

The obvious reading — `scratch_for_pod` provisions a scratch and any scratch is refused — is **wrong**, and I made it twice before checking. `clone_safety` was changed at exactly that point: *"ATTACHED is fine; MOUNTED is not … This **was** 'is a writable non-root drive attached', which refused every jailed pod."*

The refusal I hit is `Mounted`, not "attached": I had snapshotted a fully booted pod, and a booted pod has mounted `/work`. It is a timing problem, not a provisioning one.

**The real blocker is that nothing can observe the VM while it is at its barrier** — the only instant `clone_safety` can certify:

1. `guest-init` announces `SNAPSHOT_READY` and **does not stop** — best-effort by design, *"announcing a barrier is not a request for anything."*
2. The host handler declines to act on it, explicitly: *"**Recorded, not acted on.** Taking the snapshot here would make every boot wait on a decision only the operator has, so the guest is told to carry on and the host keeps the fact for whoever asks to snapshot later."*
3. So the guest proceeds to mount `/work`, and the operator's `POST /v1/pods/{id}/snapshot` — the only way to publish a base — necessarily arrives **after** the mount.

`clone_safety` is therefore **structurally unsatisfiable on the live path** for any pod with a scratch, which is every jailed pod. Not a wrong check: the certifiable instant is one nothing is positioned to catch. A synchronisation point does exist and is declined for a stated reason — the guest blocks reading the reply, *"the content is not interesting, the ordering is."*

On `origin/main` it is not even a race: `/work` mounts at `crates/nucleus-guest-init/src/main.rs:132`, before the pod spec is resolved, so the barrier is announced with the scratch already mounted. **#2867 moves that mount past the barrier and is a prerequisite for either fix.**

## Two candidate fixes, with a preference

- A pod mode that **halts at the barrier** awaiting a snapshot decision — an explicit "build me a base" pod, paying the wait once rather than on every boot, which is the cost the handler's comment is refusing.
- Deferring the `/work` mount to **first use** rather than to immediately past the barrier, so a pod that never touches `/work` stays certifiable while untouched.

The second is the better shape: no new mode, and an ordinary pod becomes usable as a base rather than needing one built for the purpose.

Docs only — no code change. Does not weaken `docs/snapshot-scratch.md`, which argues the scratch constraint is a real correctness property rather than a default to flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016t7JSuCtg4dC54HZjFgBjr
